### PR TITLE
bump deps (fix unit tests)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "code-red",
-  "version": "0.0.15",
+  "version": "0.0.17",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -193,15 +193,15 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.14.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.18.tgz",
-      "integrity": "sha512-ryO3Q3++yZC/+b8j8BdKd/dn9JlzlHBPdm80656xwYUdmPkpTGTjkAdt6BByiNupGPE8w0FhBgvYy/fX9hRNGQ==",
+      "version": "10.14.22",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.14.22.tgz",
+      "integrity": "sha512-9taxKC944BqoTVjE+UT3pQH0nHZlTvITwfsOZqyc+R3sfJuxaTtxWjfn1K2UlxyPcKHf0rnaXcVFrS9F9vf0bw==",
       "dev": true
     },
     "acorn": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.0.0.tgz",
-      "integrity": "sha512-PaF/MduxijYYt7unVGRuds1vBC9bFxbNf+VWqhOClfdgy7RlVkQqt610ig1/yxTgsDIfW1cWDel5EBbOy3jdtQ=="
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ=="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -506,9 +506,9 @@
       }
     },
     "is-reference": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.1.3.tgz",
-      "integrity": "sha512-W1iHHv/oyBb2pPxkBxtaewxa1BC58Pn5J0hogyCdefwUIvb6R+TGbAcIa4qPNYLqLhb3EnOgUf2MQkkF76BcKw==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.1.4.tgz",
+      "integrity": "sha512-uJA/CDPO3Tao3GTrxYn6AwkM4nUPJiGGYu5+cB8qbC7WGFlrKZbiRo7SFKxUAEpFUfiHofWCXBUNhvYJMh+6zw==",
       "requires": {
         "@types/estree": "0.0.39"
       }
@@ -658,21 +658,11 @@
       "dev": true
     },
     "periscopic": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/periscopic/-/periscopic-1.0.1.tgz",
-      "integrity": "sha512-JcSQ6sufVNGT04lPr2f2qGuJ2FCkZcbWBw0gQ8mzSVf9+6bEX9ea6l48+PdAekjJIHlEwSrqJND1TR2cC1FbtQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/periscopic/-/periscopic-1.0.2.tgz",
+      "integrity": "sha512-KpKBKadLf8THXOxswQBhOY8E1lVVhfUidacPtQBrq7KDXaNkQLUPiTmXagzqpJGECP3/0gDXYFO6CZHVbGvOSw==",
       "requires": {
         "is-reference": "^1.1.4"
-      },
-      "dependencies": {
-        "is-reference": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.1.4.tgz",
-          "integrity": "sha512-uJA/CDPO3Tao3GTrxYn6AwkM4nUPJiGGYu5+cB8qbC7WGFlrKZbiRo7SFKxUAEpFUfiHofWCXBUNhvYJMh+6zw==",
-          "requires": {
-            "@types/estree": "0.0.39"
-          }
-        }
       }
     },
     "pirates": {
@@ -914,9 +904,9 @@
       }
     },
     "typescript": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.3.tgz",
-      "integrity": "sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==",
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
+      "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg==",
       "dev": true
     },
     "wordwrap": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@types/astring": "^1.3.0",
     "@types/estree": "0.0.39",
     "@types/mocha": "^5.2.5",
-    "@types/node": "^10.9.4",
+    "@types/node": "^10.14.22",
     "eslump": "^2.0.0",
     "estree-walker": "^0.8.1",
     "mocha": "^5.2.0",
@@ -23,7 +23,7 @@
     "sander": "^0.6.0",
     "sucrase": "^3.9.5",
     "tiny-glob": "^0.2.6",
-    "typescript": "^3.6.2"
+    "typescript": "^3.6.4"
   },
   "scripts": {
     "build-declarations": "tsc -d && node scripts/move-type-declarations.js",
@@ -35,9 +35,9 @@
   },
   "license": "MIT",
   "dependencies": {
-    "acorn": "^7.0.0",
-    "is-reference": "^1.1.3",
-    "periscopic": "^1.0.1",
+    "acorn": "^7.1.0",
+    "is-reference": "^1.1.4",
+    "periscopic": "^1.0.2",
     "sourcemap-codec": "^1.4.6"
   }
 }


### PR DESCRIPTION
Fixes #4. Unit tests are currently failing because of a bug in periscopic@1.0.1, which was fixed in 1.0.2. This just bumps all the deps that `npm up` wanted to.