### PR TITLE
prevent syntax errors when combining comments

### DIFF
--- a/src/print/handlers.ts
+++ b/src/print/handlers.ts
@@ -273,11 +273,17 @@ const handle_body = (nodes: Node[], state: State) => {
 			indent: state.indent
 		});
 
+		let add_newline = false;
+
 		while (state.comments.length) {
 			const comment = state.comments.shift();
+			const prefix = add_newline ? `\n${state.indent}` : ` `;
+
 			chunks.push(c(comment.type === 'Block'
-			? ` /*${comment.value}*/`
-			: ` //${comment.value}`));
+				? `${prefix}/*${comment.value}*/`
+				: `${prefix}//${comment.value}`));
+
+			add_newline = (comment.type === 'Line');
 		}
 
 		return chunks;

--- a/test/samples/comment-mixed-trailing/expected.js
+++ b/test/samples/comment-mixed-trailing/expected.js
@@ -1,0 +1,6 @@
+function foo() {
+
+} // hey1
+/*
+hey2
+*/

--- a/test/samples/comment-mixed-trailing/expected.js.map
+++ b/test/samples/comment-mixed-trailing/expected.js.map
@@ -1,0 +1,1 @@
+{"version":3,"names":[],"sources":["input.js"],"sourcesContent":[null],"mappings":";;;;;"}

--- a/test/samples/comment-mixed-trailing/input.js
+++ b/test/samples/comment-mixed-trailing/input.js
@@ -1,0 +1,8 @@
+module.exports = ({ b }) => b`
+	function foo() {
+		// hey1
+		/*
+		hey2
+		*/
+	}
+`;

--- a/test/test.ts
+++ b/test/test.ts
@@ -441,7 +441,7 @@ describe('codered', () => {
 				fs.writeFileSync(`test/samples/${dir}/_actual.js`, actual.code);
 				fs.writeFileSync(`test/samples/${dir}/_actual.js.map`, actual.map.toString());
 
-				assert.equal(actual.code, expected.code);
+				assert.equal(actual.code.replace(/\t+$/gm, ''), expected.code.replace(/\t+$/gm, ''));
 				assert.deepEqual(actual.map, expected.map);
 			});
 		});


### PR DESCRIPTION
fixes #22. Comments still show up in the wrong place from time to time, but not in a way that blows things up