### PR TITLE
throw on unhandled sigils

### DIFF
--- a/src/print/index.ts
+++ b/src/print/index.ts
@@ -28,7 +28,9 @@ export function print(node: Node, opts: PrintOptions = {}): { code: string, map:
 	}
 
 	const {
-		getName = (x: string) => x
+		getName = (x: string) => {
+			throw new Error(`Unhandled sigil @${x}`);
+		}
 	} = opts;
 
 	let { map: scope_map, scope } = perisopic.analyze(node);

--- a/test/test.ts
+++ b/test/test.ts
@@ -446,6 +446,10 @@ describe('codered', () => {
 			});
 		});
 
+		it('throws on unhandled sigils', () => {
+			assert.throws(() => print(b`let foo = @bar;`), { message: 'Unhandled sigil @bar' });
+		});
+
 		it.skip('passes fuzz testing', () => {
 			for (let i = 0; i < 100; i += 1) {
 				const js = generateRandomJS({


### PR DESCRIPTION
Resolves #13. A breaking change, but it seems best to require consumers to opt into specific `getName` behavior. If someone using code-red neglects to turn some `@foo` identifier into another name during AST walking, and also doesn't specify a `getName` handler, there's probably something they're missing.