### PR TITLE
support nullish coalescing operator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -199,9 +199,9 @@
       "dev": true
     },
     "acorn": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-      "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ=="
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
+      "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA=="
     },
     "ansi-colors": {
       "version": "3.2.3",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "acorn": "^7.1.0",
+    "acorn": "^7.3.1",
     "is-reference": "^1.1.4",
     "periscopic": "^2.0.1",
     "sourcemap-codec": "^1.4.6"

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,7 @@ const EMPTY = { type: 'Empty' };
 const acorn_opts = (comments: CommentWithLocation[], raw: string) => {
 	const { onComment } = get_comment_handlers(comments, raw);
 	return {
-		ecmaVersion: 11,
+		ecmaVersion: 2020,
 		sourceType: 'module',
 		allowAwaitOutsideFunction: true,
 		allowImportExportEverywhere: true,

--- a/src/print/handlers.ts
+++ b/src/print/handlers.ts
@@ -111,8 +111,9 @@ function c(content: string, node?: Node): Chunk {
 }
 
 const OPERATOR_PRECEDENCE = {
-	'||': 3,
-	'&&': 4,
+	'||': 2,
+	'&&': 3,
+	'??': 4,
 	'|': 5,
 	'^': 6,
 	'&': 7,

--- a/src/print/handlers.ts
+++ b/src/print/handlers.ts
@@ -138,9 +138,6 @@ const OPERATOR_PRECEDENCE = {
 	'**': 13,
 };
 
-// Enables parenthesis regardless of precedence
-const NEEDS_PARENTHESES = 17;
-
 const EXPRESSIONS_PRECEDENCE: Record<string, number> = {
 	ArrayExpression: 20,
 	TaggedTemplateExpression: 20,

--- a/test/test.ts
+++ b/test/test.ts
@@ -105,11 +105,13 @@ describe('codered', () => {
 						type: 'MemberExpression',
 						object: { type: 'Identifier', name: 'console' },
 						property: { type: 'Identifier', name: 'log' },
+						optional: false,
 						computed: false
 					},
 					arguments: [
 						{ type: 'Identifier', name }
-					]
+					],
+					optional: false
 				}
 			});
 
@@ -180,7 +182,8 @@ describe('codered', () => {
 				callee: { type: 'Identifier', name: '@foo' },
 				arguments: [
 					{ type: 'Identifier', name: 'bar' }
-				]
+				],
+				optional: false
 			});
 
 			const id = x`@foo`;


### PR DESCRIPTION
Resolves #42. There's not really any particularly robust binary operator code generation and precedence tests yet, and I am going to be lazy and continue to not have any, but I did try this out locally, and this seems to be getting handled fine.