### PR TITLE
force periscopic version 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "acorn": "^7.3.1",
     "is-reference": "^1.1.4",
-    "periscopic": "^2.0.1",
+    "periscopic": "2.0.1",
     "sourcemap-codec": "^1.4.6"
   }
 }


### PR DESCRIPTION
solve issue https://github.com/sveltejs/svelte/issues/5358

code-red 0.1.3 is only working with periscopic 2.0.1

periscopic 2.0.2 is causing errors in code-red:
TypeError: Cannot read property 'find_owner' of undefined

https://github.com/Rich-Harris/code-red/blob/f2cd25dc8ece88de70560fa7e5f244322c3ac5b9/src/print/handlers.ts#L1355-L1361


