### PR TITLE
Fix broken deps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,14 +24,6 @@
         "lodash": "^4.2.0",
         "source-map": "^0.5.0",
         "trim-right": "^1.0.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.5.7",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-          "dev": true
-        }
       }
     },
     "@babel/helper-function-name": {
@@ -231,9 +223,9 @@
       }
     },
     "@types/estree": {
-      "version": "0.0.46",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
-      "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
+      "version": "0.0.45",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.45.tgz",
+      "integrity": "sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g=="
     },
     "@types/mocha": {
       "version": "5.2.7",
@@ -1190,22 +1182,6 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
-      },
-      "dependencies": {
-        "glob": {
-          "version": "7.1.4",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
-          }
-        }
       }
     },
     "rollup": {
@@ -1294,6 +1270,12 @@
           "dev": true
         }
       }
+    },
+    "source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
     },
     "sourcemap-codec": {
       "version": "1.4.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -171,6 +171,55 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@rollup/plugin-node-resolve": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-node-resolve/-/plugin-node-resolve-11.1.1.tgz",
+      "integrity": "sha512-zlBXR4eRS+2m79TsUZWhsd0slrHUYdRx4JF+aVQm+MI0wsKdlpC2vlDVjmlGvtZY1vsefOT9w3JxvmWSBei+Lg==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "@types/resolve": "1.17.1",
+        "builtin-modules": "^3.1.0",
+        "deepmerge": "^4.2.2",
+        "is-module": "^1.0.0",
+        "resolve": "^1.19.0"
+      }
+    },
+    "@rollup/plugin-sucrase": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-sucrase/-/plugin-sucrase-3.1.0.tgz",
+      "integrity": "sha512-PZ70LDNgIj8rL+3pKwKwTBOQ2c9JofXeLbWz+2V4/nCt4LqwYTNqxJJf1riTJsVARVzJdA0woIzUzjKZvL8TfA==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.0.1",
+        "sucrase": "^3.10.1"
+      }
+    },
+    "@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "requires": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "dependencies": {
+        "@types/estree": {
+          "version": "0.0.39",
+          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+          "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+          "dev": true
+        },
+        "estree-walker": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+          "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+          "dev": true
+        }
+      }
+    },
     "@types/astring": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@types/astring/-/astring-1.3.0.tgz",
@@ -182,10 +231,9 @@
       }
     },
     "@types/estree": {
-      "version": "0.0.45",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.45.tgz",
-      "integrity": "sha512-jnqIUKDUqJbDIUxm0Uj7bnlMnRm1T/eZ9N+AVMqhPgzrba2GhGG5o/jCTwmdPK709nEZsGoMzXEDUjcXHa3W0g==",
-      "dev": true
+      "version": "0.0.46",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.46.tgz",
+      "integrity": "sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg=="
     },
     "@types/mocha": {
       "version": "5.2.7",
@@ -199,10 +247,19 @@
       "integrity": "sha512-E6Zn0rffhgd130zbCbAr/JdXfXkoOUFAKNs/rF8qnafSJ8KYaA/j3oz7dcwal+lYjLA7xvdd5J4wdYpCTlP8+w==",
       "dev": true
     },
+    "@types/resolve": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.17.1.tgz",
+      "integrity": "sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "acorn": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
-      "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA=="
+      "version": "8.0.5",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.0.5.tgz",
+      "integrity": "sha512-v+DieK/HJkJOpFBETDJioequtc3PfxsWMaxIdIwujtF7FEV/MAyDQLlm6/zPvr7Mix07mLh6ccVwIsloceodlg=="
     },
     "ansi-colors": {
       "version": "3.2.3",
@@ -310,6 +367,12 @@
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
+    "builtin-modules": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.2.0.tgz",
+      "integrity": "sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==",
+      "dev": true
+    },
     "camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -381,6 +444,12 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "commander": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+      "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+      "dev": true
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -406,6 +475,12 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
       "dev": true
     },
     "define-properties": {
@@ -520,8 +595,7 @@
     "estree-walker": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.9.0.tgz",
-      "integrity": "sha512-12U47o7XHUX329+x3FzNVjCx3SHEzMF0nkDv7r/HnBzX/xNTKxajBk6gyygaxrAFtLj39219oMfbtxv4KpaOiA==",
-      "dev": true
+      "integrity": "sha512-12U47o7XHUX329+x3FzNVjCx3SHEzMF0nkDv7r/HnBzX/xNTKxajBk6gyygaxrAFtLj39219oMfbtxv4KpaOiA=="
     },
     "esutils": {
       "version": "2.0.3",
@@ -558,6 +632,13 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
+    },
+    "fsevents": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.1.tgz",
+      "integrity": "sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==",
+      "dev": true,
+      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -679,6 +760,15 @@
       "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA==",
       "dev": true
     },
+    "is-core-module": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.2.0.tgz",
+      "integrity": "sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3"
+      }
+    },
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
@@ -691,19 +781,18 @@
       "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
       "dev": true
     },
+    "is-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
+      "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
+      "dev": true
+    },
     "is-reference": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.1.4.tgz",
-      "integrity": "sha512-uJA/CDPO3Tao3GTrxYn6AwkM4nUPJiGGYu5+cB8qbC7WGFlrKZbiRo7SFKxUAEpFUfiHofWCXBUNhvYJMh+6zw==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-2.0.0.tgz",
+      "integrity": "sha512-kgaeJVq59jasPrhlGK/K61muTjLxMOZf4oMwI4X94nDWqkqLxDWVWrecCSP5c6OR8JF7Yul0X7h59lB1ho0epQ==",
       "requires": {
-        "@types/estree": "0.0.39"
-      },
-      "dependencies": {
-        "@types/estree": {
-          "version": "0.0.39",
-          "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
-          "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw=="
-        }
+        "@types/estree": "*"
       }
     },
     "is-regex": {
@@ -1015,13 +1104,35 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
     "periscopic": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/periscopic/-/periscopic-2.0.1.tgz",
       "integrity": "sha512-twJ8e4RatllMAcbmBqKj8cvZ94HtqSzbb8hJoGj4iSCcCHXxKb06HRxOq4heyq2x/6mKynJDvTTreHCz+m6lJw==",
       "requires": {
         "is-reference": "^1.1.4"
+      },
+      "dependencies": {
+        "is-reference": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
+          "integrity": "sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==",
+          "requires": {
+            "@types/estree": "*"
+          }
+        }
       }
+    },
+    "picomatch": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
+      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "dev": true
     },
     "pirates": {
       "version": "4.0.1",
@@ -1062,6 +1173,16 @@
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
     },
+    "resolve": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+      "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+      "dev": true,
+      "requires": {
+        "is-core-module": "^2.1.0",
+        "path-parse": "^1.0.6"
+      }
+    },
     "rimraf": {
       "version": "2.7.1",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
@@ -1088,41 +1209,12 @@
       }
     },
     "rollup": {
-      "version": "1.26.5",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-1.26.5.tgz",
-      "integrity": "sha512-c6Pv0yWzjYNpy2DIhLFUnyP6e1UTGownr4IfpJcPY/k186RJjpaGGPRwKQ62KCauctG6dgtHt88pw1EGrPRkuA==",
+      "version": "2.38.3",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.38.3.tgz",
+      "integrity": "sha512-FVx/XzR2DtCozKNDBjHJCHIgkC12rNg/ruAeoYWjLeeKfSKgwhh+lDLDhuCkuRG/fsup8py8dKBTlHdvUFX32A==",
       "dev": true,
       "requires": {
-        "@types/estree": "*",
-        "@types/node": "*",
-        "acorn": "^7.1.0"
-      }
-    },
-    "rollup-plugin-sucrase": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-sucrase/-/rollup-plugin-sucrase-2.1.0.tgz",
-      "integrity": "sha512-chdA3OruR1FH/IIKrzZCpGKLXAx3DOHoK24RIPtlVccK0wbTpHE0HpGEQYCxte1XaB17NgRe/frFyKR7g45qxQ==",
-      "dev": true,
-      "requires": {
-        "rollup-pluginutils": "^2.3.0",
-        "sucrase": "3.x"
-      }
-    },
-    "rollup-pluginutils": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
-      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
-      "dev": true,
-      "requires": {
-        "estree-walker": "^0.6.1"
-      },
-      "dependencies": {
-        "estree-walker": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-          "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-          "dev": true
-        }
+        "fsevents": "~2.3.1"
       }
     },
     "sander": {
@@ -1204,9 +1296,9 @@
       }
     },
     "sourcemap-codec": {
-      "version": "1.4.6",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.6.tgz",
-      "integrity": "sha512-1ZooVLYFxC448piVLBbtOxFcXwnymH9oUF8nRd3CuYDVvkRBxRl6pB4Mtas5a4drtL+E8LDgFkQNcgIw6tc8Hg=="
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -1260,22 +1352,32 @@
       "dev": true
     },
     "sucrase": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.10.1.tgz",
-      "integrity": "sha512-nMOs6rFWwkYRxcKHHDjyQmC5CmLbHN2LwRyWF1n2i0kb/pq0xcB9M19TdY5Ivfcj1BsWfs+az9Ga5B0tFdE5ww==",
+      "version": "3.17.1",
+      "resolved": "https://registry.npmjs.org/sucrase/-/sucrase-3.17.1.tgz",
+      "integrity": "sha512-04cNLFAhS4NBG2Z/MTkLY6HdoBsqErv3wCncymFlfFtnpMthurlWYML2RlID4M2BbiJSu1eZdQnE8Lcz4PCe2g==",
       "dev": true,
       "requires": {
-        "commander": "^2.19.0",
+        "commander": "^4.0.0",
+        "glob": "7.1.6",
         "lines-and-columns": "^1.1.6",
         "mz": "^2.7.0",
-        "pirates": "^4.0.0"
+        "pirates": "^4.0.1",
+        "ts-interface-checker": "^0.1.9"
       },
       "dependencies": {
-        "commander": {
-          "version": "2.20.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==",
-          "dev": true
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
         }
       }
     },
@@ -1289,9 +1391,9 @@
       }
     },
     "thenify": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
-      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
       "dev": true,
       "requires": {
         "any-promise": "^1.0.0"
@@ -1326,6 +1428,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
       "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
+    },
+    "ts-interface-checker": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+      "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true
     },
     "type-check": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "@rollup/plugin-node-resolve": "^11.1.1",
     "@rollup/plugin-sucrase": "^3.1.0",
     "@types/astring": "^1.3.0",
-    "@types/estree": "0.0.46",
     "@types/mocha": "^5.2.7",
     "@types/node": "^12.12.7",
     "eslump": "^2.0.0",
@@ -35,13 +34,11 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@types/estree": "^0.0.45",
     "acorn": "^8.0.5",
     "estree-walker": "^0.9.0",
     "is-reference": "^2.0.0",
     "periscopic": "^2.0.1",
     "sourcemap-codec": "^1.4.8"
-  },
-  "peerDependencies": {
-    "@types/estree": "^0.0.45"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,43 +1,47 @@
 {
-  "name": "code-red",
-  "description": "code-red",
-  "version": "0.1.4",
-  "repository": "Rich-Harris/code-red",
-  "main": "dist/code-red.js",
-  "module": "dist/code-red.mjs",
-  "types": "types/index.d.ts",
-  "files": [
-    "dist",
-    "types"
-  ],
-  "devDependencies": {
-    "@types/astring": "^1.3.0",
-    "@types/estree": "0.0.45",
-    "@types/mocha": "^5.2.7",
-    "@types/node": "^12.12.7",
-    "eslump": "^2.0.0",
-    "estree-walker": "^0.9.0",
-    "mocha": "^6.2.2",
-    "rollup": "^1.26.5",
-    "rollup-plugin-sucrase": "^2.1.0",
-    "sander": "^0.6.0",
-    "sucrase": "^3.10.1",
-    "tiny-glob": "^0.2.6",
-    "typescript": "^3.7.2"
-  },
-  "scripts": {
-    "build-declarations": "tsc -d && node scripts/move-type-declarations.js",
-    "build": "npm run build-declarations && rollup -c",
-    "dev": "rollup -cw",
-    "test": "mocha --opts mocha.opts",
-    "prepublishOnly": "npm test && npm run build",
-    "repl": "node -e \"const { x, b, print } = require('./')\" -i"
-  },
-  "license": "MIT",
-  "dependencies": {
-    "acorn": "^7.3.1",
-    "is-reference": "^1.1.4",
-    "periscopic": "^2.0.1",
-    "sourcemap-codec": "^1.4.6"
-  }
+	"name": "code-red",
+	"description": "code-red",
+	"version": "0.1.4",
+	"repository": "Rich-Harris/code-red",
+	"main": "dist/code-red.js",
+	"module": "dist/code-red.mjs",
+	"types": "types/index.d.ts",
+	"files": [
+		"dist",
+		"types"
+	],
+	"devDependencies": {
+		"@rollup/plugin-node-resolve": "^11.1.1",
+		"@rollup/plugin-sucrase": "^3.1.0",
+		"@types/astring": "^1.3.0",
+		"@types/estree": "0.0.46",
+		"@types/mocha": "^5.2.7",
+		"@types/node": "^12.12.7",
+		"eslump": "^2.0.0",
+		"mocha": "^6.2.2",
+		"rollup": "^2.38.1",
+		"sander": "^0.6.0",
+		"sucrase": "^3.17.0",
+		"tiny-glob": "^0.2.6",
+		"typescript": "^3.7.2"
+	},
+	"scripts": {
+		"build-declarations": "tsc -d && node scripts/move-type-declarations.js",
+		"build": "npm run build-declarations && rollup -c",
+		"dev": "rollup -cw",
+		"test": "mocha --opts mocha.opts",
+		"prepublishOnly": "npm test && npm run build",
+		"repl": "node -e \"const { x, b, print } = require('./')\" -i"
+	},
+	"license": "MIT",
+	"dependencies": {
+		"acorn": "^8.0.5",
+		"estree-walker": "^0.9.0",
+		"is-reference": "^2.0.0",
+		"periscopic": "^2.0.1",
+		"sourcemap-codec": "^1.4.8"
+	},
+	"peerDependencies": {
+		"@types/estree": "^0.0.45"
+	}
 }

--- a/package.json
+++ b/package.json
@@ -1,47 +1,47 @@
 {
-	"name": "code-red",
-	"description": "code-red",
-	"version": "0.1.4",
-	"repository": "Rich-Harris/code-red",
-	"main": "dist/code-red.js",
-	"module": "dist/code-red.mjs",
-	"types": "types/index.d.ts",
-	"files": [
-		"dist",
-		"types"
-	],
-	"devDependencies": {
-		"@rollup/plugin-node-resolve": "^11.1.1",
-		"@rollup/plugin-sucrase": "^3.1.0",
-		"@types/astring": "^1.3.0",
-		"@types/estree": "0.0.46",
-		"@types/mocha": "^5.2.7",
-		"@types/node": "^12.12.7",
-		"eslump": "^2.0.0",
-		"mocha": "^6.2.2",
-		"rollup": "^2.38.1",
-		"sander": "^0.6.0",
-		"sucrase": "^3.17.0",
-		"tiny-glob": "^0.2.6",
-		"typescript": "^3.7.2"
-	},
-	"scripts": {
-		"build-declarations": "tsc -d && node scripts/move-type-declarations.js",
-		"build": "npm run build-declarations && rollup -c",
-		"dev": "rollup -cw",
-		"test": "mocha --opts mocha.opts",
-		"prepublishOnly": "npm test && npm run build",
-		"repl": "node -e \"const { x, b, print } = require('./')\" -i"
-	},
-	"license": "MIT",
-	"dependencies": {
-		"acorn": "^8.0.5",
-		"estree-walker": "^0.9.0",
-		"is-reference": "^2.0.0",
-		"periscopic": "^2.0.1",
-		"sourcemap-codec": "^1.4.8"
-	},
-	"peerDependencies": {
-		"@types/estree": "^0.0.45"
-	}
+  "name": "code-red",
+  "description": "code-red",
+  "version": "0.1.4",
+  "repository": "Rich-Harris/code-red",
+  "main": "dist/code-red.js",
+  "module": "dist/code-red.mjs",
+  "types": "types/index.d.ts",
+  "files": [
+    "dist",
+    "types"
+  ],
+  "devDependencies": {
+    "@rollup/plugin-node-resolve": "^11.1.1",
+    "@rollup/plugin-sucrase": "^3.1.0",
+    "@types/astring": "^1.3.0",
+    "@types/estree": "0.0.46",
+    "@types/mocha": "^5.2.7",
+    "@types/node": "^12.12.7",
+    "eslump": "^2.0.0",
+    "mocha": "^6.2.2",
+    "rollup": "^2.38.1",
+    "sander": "^0.6.0",
+    "sucrase": "^3.17.0",
+    "tiny-glob": "^0.2.6",
+    "typescript": "^3.7.2"
+  },
+  "scripts": {
+    "build-declarations": "tsc -d && node scripts/move-type-declarations.js",
+    "build": "npm run build-declarations && rollup -c",
+    "dev": "rollup -cw",
+    "test": "mocha --opts mocha.opts",
+    "prepublishOnly": "npm test && npm run build",
+    "repl": "node -e \"const { x, b, print } = require('./')\" -i"
+  },
+  "license": "MIT",
+  "dependencies": {
+    "acorn": "^8.0.5",
+    "estree-walker": "^0.9.0",
+    "is-reference": "^2.0.0",
+    "periscopic": "^2.0.1",
+    "sourcemap-codec": "^1.4.8"
+  },
+  "peerDependencies": {
+    "@types/estree": "^0.0.45"
+  }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,15 +1,21 @@
-import sucrase from 'rollup-plugin-sucrase';
+import sucrase from '@rollup/plugin-sucrase';
+import resolve from '@rollup/plugin-node-resolve';
 import pkg from './package.json';
+import path from 'path';
 
 export default {
 	input: 'src/index.ts',
 	output: [
 		{ file: pkg.main, format: 'umd', name: 'CodeRed' },
-		{ file: pkg.module, format: 'esm' }
+		{ file: pkg.module, format: 'esm' },
 	],
 	plugins: [
+		resolve({
+			extensions: ['.js', '.ts'],
+			jail: path.resolve(__dirname, 'src'),
+		}),
 		sucrase({
-			transforms: ['typescript']
-		})
-	]
+			transforms: ['typescript'],
+		}),
+	],
 };


### PR DESCRIPTION
## Description

Using code-red in [Runkit](https://runkit.com/) currently fails, due to missing dependencies. I prepared a a demo REPL here: https://runkit.com/mister-what/code-red

This PR fixes the dependency definitions in the `package.json`. I also updated the build tooling, as I was running into problems when trying to run the build locally.

I also took care to follow the the [official guide](https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html#dependencies) for a good DX when using code-red with typescript.