### PR TITLE
[fix] introduce helper method to prevent push maximum call stack size exceeded error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,653 +1,1437 @@
 {
-  "name": "code-red",
-  "version": "0.2.4",
-  "lockfileVersion": 1,
-  "requires": true,
-  "dependencies": {
-    "@babel/code-frame": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-      "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
-      "dev": true,
-      "requires": {
-        "@babel/highlight": "^7.0.0"
-      }
-    },
-    "@babel/generator": {
-      "version": "7.0.0-beta.44",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.44.tgz",
-      "integrity": "sha512-5xVb7hlhjGcdkKpMXgicAVgx8syK5VJz193k0i/0sLP6DzE6lRrU1K3B/rFefgdo9LPGMAOOOAWW4jycj07ShQ==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "7.0.0-beta.44",
-        "jsesc": "^2.5.1",
-        "lodash": "^4.2.0",
-        "source-map": "^0.5.0",
-        "trim-right": "^1.0.1"
-      }
-    },
-    "@babel/helper-function-name": {
-      "version": "7.0.0-beta.44",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
-      "integrity": "sha512-MHRG2qZMKMFaBavX0LWpfZ2e+hLloT++N7rfM3DYOMUOGCD8cVjqZpwiL8a0bOX3IYcQev1ruciT0gdFFRTxzg==",
-      "dev": true,
-      "requires": {
-        "@babel/helper-get-function-arity": "7.0.0-beta.44",
-        "@babel/template": "7.0.0-beta.44",
-        "@babel/types": "7.0.0-beta.44"
-      }
-    },
-    "@babel/helper-get-function-arity": {
-      "version": "7.0.0-beta.44",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
-      "integrity": "sha512-w0YjWVwrM2HwP6/H3sEgrSQdkCaxppqFeJtAnB23pRiJB5E/O9Yp7JAAeWBl+gGEgmBFinnTyOv2RN7rcSmMiw==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "7.0.0-beta.44"
-      }
-    },
-    "@babel/helper-split-export-declaration": {
-      "version": "7.0.0-beta.44",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
-      "integrity": "sha512-aQ7QowtkgKKzPGf0j6u77kBMdUFVBKNHw2p/3HX/POt5/oz8ec5cs0GwlgM8Hz7ui5EwJnzyfRmkNF1Nx1N7aA==",
-      "dev": true,
-      "requires": {
-        "@babel/types": "7.0.0-beta.44"
-      }
-    },
-    "@babel/highlight": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
-      "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
-      "dev": true,
-      "requires": {
-        "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
-        "js-tokens": "^4.0.0"
-      }
-    },
-    "@babel/template": {
-      "version": "7.0.0-beta.44",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
-      "integrity": "sha512-w750Sloq0UNifLx1rUqwfbnC6uSUk0mfwwgGRfdLiaUzfAOiH0tHJE6ILQIUi3KYkjiCDTskoIsnfqZvWLBDng==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "7.0.0-beta.44",
-        "@babel/types": "7.0.0-beta.44",
-        "babylon": "7.0.0-beta.44",
-        "lodash": "^4.2.0"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
-          "integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "7.0.0-beta.44"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
-          "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-          "dev": true
-        }
-      }
-    },
-    "@babel/traverse": {
-      "version": "7.0.0-beta.44",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.44.tgz",
-      "integrity": "sha512-UHuDz8ukQkJCDASKHf+oDt3FVUzFd+QYfuBIsiNu/4+/ix6pP/C+uQZJ6K1oEfbCMv/IKWbgDEh7fcsnIE5AtA==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "7.0.0-beta.44",
-        "@babel/generator": "7.0.0-beta.44",
-        "@babel/helper-function-name": "7.0.0-beta.44",
-        "@babel/helper-split-export-declaration": "7.0.0-beta.44",
-        "@babel/types": "7.0.0-beta.44",
-        "babylon": "7.0.0-beta.44",
-        "debug": "^3.1.0",
-        "globals": "^11.1.0",
-        "invariant": "^2.2.0",
-        "lodash": "^4.2.0"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
-          "integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "7.0.0-beta.44"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
-          "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-          "dev": true
-        }
-      }
-    },
-    "@babel/types": {
-      "version": "7.0.0-beta.44",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
-      "integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
-      "dev": true,
-      "requires": {
-        "esutils": "^2.0.2",
-        "lodash": "^4.2.0",
-        "to-fast-properties": "^2.0.0"
-      }
-    },
-    "@types/estree": {
-      "version": "0.0.50",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
-      "integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
-    },
-    "@types/node": {
-      "version": "12.12.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.7.tgz",
-      "integrity": "sha512-E6Zn0rffhgd130zbCbAr/JdXfXkoOUFAKNs/rF8qnafSJ8KYaA/j3oz7dcwal+lYjLA7xvdd5J4wdYpCTlP8+w==",
-      "dev": true
-    },
-    "acorn": {
-      "version": "8.0.5",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.0.5.tgz",
-      "integrity": "sha512-v+DieK/HJkJOpFBETDJioequtc3PfxsWMaxIdIwujtF7FEV/MAyDQLlm6/zPvr7Mix07mLh6ccVwIsloceodlg=="
-    },
-    "ansi-styles": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
-      "requires": {
-        "color-convert": "^1.9.0"
-      }
-    },
-    "babel-eslint": {
-      "version": "8.2.6",
-      "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.6.tgz",
-      "integrity": "sha512-aCdHjhzcILdP8c9lej7hvXKvQieyRt20SF102SIGyY4cUIiw6UaAtK4j2o3dXX74jEmy0TJ0CEhv4fTIM3SzcA==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "7.0.0-beta.44",
-        "@babel/traverse": "7.0.0-beta.44",
-        "@babel/types": "7.0.0-beta.44",
-        "babylon": "7.0.0-beta.44",
-        "eslint-scope": "3.7.1",
-        "eslint-visitor-keys": "^1.0.0"
-      },
-      "dependencies": {
-        "@babel/code-frame": {
-          "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
-          "integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
-          "dev": true,
-          "requires": {
-            "@babel/highlight": "7.0.0-beta.44"
-          }
-        },
-        "@babel/highlight": {
-          "version": "7.0.0-beta.44",
-          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
-          "integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.0.0",
-            "esutils": "^2.0.2",
-            "js-tokens": "^3.0.0"
-          }
-        },
-        "js-tokens": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-          "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-          "dev": true
-        }
-      }
-    },
-    "babylon": {
-      "version": "7.0.0-beta.44",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
-      "integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
-      "dev": true
-    },
-    "chalk": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^3.2.1",
-        "escape-string-regexp": "^1.0.5",
-        "supports-color": "^5.3.0"
-      }
-    },
-    "color-convert": {
-      "version": "1.9.3",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
-      "requires": {
-        "color-name": "1.1.3"
-      }
-    },
-    "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
-    },
-    "debug": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-      "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-      "dev": true,
-      "requires": {
-        "ms": "2.0.0"
-      }
-    },
-    "deep-is": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-      "dev": true
-    },
-    "dequal": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
-      "integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==",
-      "dev": true
-    },
-    "esbuild": {
-      "version": "0.11.16",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.11.16.tgz",
-      "integrity": "sha512-34ZWjo4ouvM5cDe7uRoM9GFuMyEmpH9fnVYmomvS1cq9ED9d/0ZG1r+p4P2VbX7ihjv36zA2SWTmP8Zmt/EANA==",
-      "dev": true
-    },
-    "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
-    },
-    "eslint-scope": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-      "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
-      "dev": true,
-      "requires": {
-        "esrecurse": "^4.1.0",
-        "estraverse": "^4.1.1"
-      }
-    },
-    "eslint-visitor-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
-      "dev": true
-    },
-    "eslump": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/eslump/-/eslump-2.0.0.tgz",
-      "integrity": "sha512-80p4ogK1rh8LWyTIRAeL4BEC1sSP0O/8JYNygSvLQXN0+zhKlTtRsESOsBUU+POHNISTifbefaEJNqpqZQxdKQ==",
-      "dev": true,
-      "requires": {
-        "@babel/code-frame": "^7.0.0",
-        "mkdirp": "^0.5.1",
-        "optionator": "^0.8.2",
-        "random-int": "^1.0.0",
-        "random-item": "^1.0.0",
-        "shift-codegen": "5.1.0",
-        "shift-fuzzer": "^1.0.2",
-        "shift-reducer": "^5.0.0"
-      }
-    },
-    "esrecurse": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
-      "dev": true,
-      "requires": {
-        "estraverse": "^4.1.0"
-      }
-    },
-    "estraverse": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-      "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-      "dev": true
-    },
-    "estree-walker": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.0.tgz",
-      "integrity": "sha512-s6ceX0NFiU/vKPiKvFdR83U1Zffu7upwZsGwpoqfg5rbbq1l50WQ5hCeIvM6E6oD4shUHCYMsiFPns4Jk0YfMQ=="
-    },
-    "esutils": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-      "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-      "dev": true
-    },
-    "fast-levenshtein": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-      "dev": true
-    },
-    "globals": {
-      "version": "11.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-      "dev": true
-    },
-    "has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
-    },
-    "invariant": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.0.0"
-      }
-    },
-    "is-reference": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.0.tgz",
-      "integrity": "sha512-Eo1W3wUoHWoCoVM4GVl/a+K0IgiqE5aIo4kJABFyMum1ZORlPkC+UC357sSQUL5w5QCE5kCC9upl75b7+7CY/Q==",
-      "requires": {
-        "@types/estree": "*"
-      }
-    },
-    "js-tokens": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
-    },
-    "jsesc": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-      "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-      "dev": true
-    },
-    "kleur": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
-      "integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
-      "dev": true
-    },
-    "levn": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2"
-      }
-    },
-    "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
-    },
-    "loose-envify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
-      "requires": {
-        "js-tokens": "^3.0.0 || ^4.0.0"
-      }
-    },
-    "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-      "dev": true
-    },
-    "mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "dev": true,
-      "requires": {
-        "minimist": "^1.2.5"
-      }
-    },
-    "mri": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.6.tgz",
-      "integrity": "sha512-oi1b3MfbyGa7FJMP9GmLTttni5JoICpYBRlq+x5V16fZbLsnL9N3wFqqIm/nIG43FjUFkFh9Epzp/kzUGUnJxQ==",
-      "dev": true
-    },
-    "ms": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
-    },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
-    },
-    "optionator": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true,
-      "requires": {
-        "deep-is": "~0.1.3",
-        "fast-levenshtein": "~2.0.4",
-        "levn": "~0.3.0",
-        "prelude-ls": "~1.1.2",
-        "type-check": "~0.3.2",
-        "wordwrap": "~1.0.0"
-      }
-    },
-    "periscopic": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.0.4.tgz",
-      "integrity": "sha512-SFx68DxCv0Iyo6APZuw/AKewkkThGwssmU0QWtTlvov3VAtPX+QJ4CadwSaz8nrT5jPIuxdvJWB4PnD2KNDxQg==",
-      "requires": {
-        "estree-walker": "^3.0.0",
-        "is-reference": "^3.0.0"
-      }
-    },
-    "prelude-ls": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-      "dev": true
-    },
-    "random-int": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/random-int/-/random-int-1.0.0.tgz",
-      "integrity": "sha1-5qLtNEisnGZGoGV0Q7HBUhWS7Qg=",
-      "dev": true
-    },
-    "random-item": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/random-item/-/random-item-1.0.0.tgz",
-      "integrity": "sha1-Fu4xYmywUMihaGpfD0KmuZoqrxE=",
-      "dev": true
-    },
-    "sade": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/sade/-/sade-1.7.4.tgz",
-      "integrity": "sha512-y5yauMD93rX840MwUJr7C1ysLFBgMspsdTo4UVrDg3fXDvtwOyIqykhVAAm6fk/3au77773itJStObgK+LKaiA==",
-      "dev": true,
-      "requires": {
-        "mri": "^1.1.0"
-      }
-    },
-    "shift-ast": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/shift-ast/-/shift-ast-4.0.0.tgz",
-      "integrity": "sha1-HUFSoq3ShkSlKusuDIfYkl09l/8=",
-      "dev": true
-    },
-    "shift-codegen": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/shift-codegen/-/shift-codegen-5.1.0.tgz",
-      "integrity": "sha512-OpRpMYukx4uNyZl+4j192qlghA+orUuXQwCxGB4C7XWVCeFOoz9MVCAQ9XNMQqeZKHE9YNoMpBA/kzrVUFpqcQ==",
-      "dev": true,
-      "requires": {
-        "babel-eslint": "^8.2.2",
-        "esutils": "^2.0.2",
-        "object-assign": "^4.1.0",
-        "shift-reducer": "^4.3.0"
-      },
-      "dependencies": {
-        "shift-reducer": {
-          "version": "4.4.1",
-          "resolved": "https://registry.npmjs.org/shift-reducer/-/shift-reducer-4.4.1.tgz",
-          "integrity": "sha512-IJmk9grLnuO8vLSG5e52wFXaDLXJmVMGPXKQljhh/Pwb1mQL8OgCr6c4OYyIa3OInTH9rBtms3SwDFWsJzVEnA==",
-          "dev": true,
-          "requires": {
-            "shift-ast": "^4.0.0"
-          }
-        }
-      }
-    },
-    "shift-fuzzer": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/shift-fuzzer/-/shift-fuzzer-1.0.2.tgz",
-      "integrity": "sha1-g7uuFHv2Aiqupyc+LiviJamZVys=",
-      "dev": true,
-      "requires": {
-        "shift-ast": "^4.0.0"
-      }
-    },
-    "shift-reducer": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/shift-reducer/-/shift-reducer-5.0.0.tgz",
-      "integrity": "sha512-Jgr6kPMZuzsQ63NdeLJT6BZvtJ6IDbYFBVqiid1bZlwxeJYq81Cj2Wc4UUERjO4Q9tz5U4KpWaZhitjcBvfiYA==",
-      "dev": true,
-      "requires": {
-        "shift-ast": "5.0.0"
-      },
-      "dependencies": {
-        "shift-ast": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/shift-ast/-/shift-ast-5.0.0.tgz",
-          "integrity": "sha512-kMhr/GwgrQ1U2kaa50sD5YxNDQEZHAZigVwrf/NNeezb6oiYnpPMV8v1WVRhCW8sjI7xUdzuPujSQ3gA2IuUAQ==",
-          "dev": true
-        }
-      }
-    },
-    "source-map": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-      "dev": true
-    },
-    "sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
-    },
-    "supports-color": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
-      "dev": true,
-      "requires": {
-        "has-flag": "^3.0.0"
-      }
-    },
-    "to-fast-properties": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-      "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-      "dev": true
-    },
-    "totalist": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/totalist/-/totalist-2.0.0.tgz",
-      "integrity": "sha512-+Y17F0YzxfACxTyjfhnJQEe7afPA0GSpYlFkl2VFMxYP7jshQf9gXV7cH47EfToBumFThfKBvfAcoUn6fdNeRQ==",
-      "dev": true
-    },
-    "trim-right": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-      "dev": true
-    },
-    "type-check": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "~1.1.2"
-      }
-    },
-    "typescript": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
-      "integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==",
-      "dev": true
-    },
-    "uvu": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.1.tgz",
-      "integrity": "sha512-JGxttnOGDFs77FaZ0yMUHIzczzQ5R1IlDeNW6Wymw6gAscwMdAffVOP6TlxLIfReZyK8tahoGwWZaTCJzNFDkg==",
-      "dev": true,
-      "requires": {
-        "dequal": "^2.0.0",
-        "diff": "^5.0.0",
-        "kleur": "^4.0.3",
-        "sade": "^1.7.3",
-        "totalist": "^2.0.0"
-      },
-      "dependencies": {
-        "diff": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-          "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
-          "dev": true
-        }
-      }
-    },
-    "wordwrap": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-      "dev": true
-    }
-  }
+	"name": "code-red",
+	"version": "0.2.4",
+	"lockfileVersion": 2,
+	"requires": true,
+	"packages": {
+		"": {
+			"name": "code-red",
+			"version": "0.2.4",
+			"license": "MIT",
+			"dependencies": {
+				"@types/estree": "^0.0.50",
+				"acorn": "^8.0.5",
+				"estree-walker": "^3.0.0",
+				"is-reference": "^3.0.0",
+				"periscopic": "^3.0.4",
+				"sourcemap-codec": "^1.4.8"
+			},
+			"devDependencies": {
+				"@types/node": "^12.12.7",
+				"esbuild": "^0.11.16",
+				"eslump": "^2.0.0",
+				"typescript": "^3.7.2",
+				"uvu": "^0.5.1"
+			}
+		},
+		"node_modules/@babel/code-frame": {
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+			"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/highlight": "^7.0.0"
+			}
+		},
+		"node_modules/@babel/generator": {
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.44.tgz",
+			"integrity": "sha512-5xVb7hlhjGcdkKpMXgicAVgx8syK5VJz193k0i/0sLP6DzE6lRrU1K3B/rFefgdo9LPGMAOOOAWW4jycj07ShQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/types": "7.0.0-beta.44",
+				"jsesc": "^2.5.1",
+				"lodash": "^4.2.0",
+				"source-map": "^0.5.0",
+				"trim-right": "^1.0.1"
+			}
+		},
+		"node_modules/@babel/helper-function-name": {
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
+			"integrity": "sha512-MHRG2qZMKMFaBavX0LWpfZ2e+hLloT++N7rfM3DYOMUOGCD8cVjqZpwiL8a0bOX3IYcQev1ruciT0gdFFRTxzg==",
+			"dev": true,
+			"dependencies": {
+				"@babel/helper-get-function-arity": "7.0.0-beta.44",
+				"@babel/template": "7.0.0-beta.44",
+				"@babel/types": "7.0.0-beta.44"
+			}
+		},
+		"node_modules/@babel/helper-get-function-arity": {
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
+			"integrity": "sha512-w0YjWVwrM2HwP6/H3sEgrSQdkCaxppqFeJtAnB23pRiJB5E/O9Yp7JAAeWBl+gGEgmBFinnTyOv2RN7rcSmMiw==",
+			"dev": true,
+			"dependencies": {
+				"@babel/types": "7.0.0-beta.44"
+			}
+		},
+		"node_modules/@babel/helper-split-export-declaration": {
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
+			"integrity": "sha512-aQ7QowtkgKKzPGf0j6u77kBMdUFVBKNHw2p/3HX/POt5/oz8ec5cs0GwlgM8Hz7ui5EwJnzyfRmkNF1Nx1N7aA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/types": "7.0.0-beta.44"
+			}
+		},
+		"node_modules/@babel/highlight": {
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
+			"integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^2.0.0",
+				"esutils": "^2.0.2",
+				"js-tokens": "^4.0.0"
+			}
+		},
+		"node_modules/@babel/template": {
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
+			"integrity": "sha512-w750Sloq0UNifLx1rUqwfbnC6uSUk0mfwwgGRfdLiaUzfAOiH0tHJE6ILQIUi3KYkjiCDTskoIsnfqZvWLBDng==",
+			"dev": true,
+			"dependencies": {
+				"@babel/code-frame": "7.0.0-beta.44",
+				"@babel/types": "7.0.0-beta.44",
+				"babylon": "7.0.0-beta.44",
+				"lodash": "^4.2.0"
+			}
+		},
+		"node_modules/@babel/template/node_modules/@babel/code-frame": {
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
+			"integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
+			"dev": true,
+			"dependencies": {
+				"@babel/highlight": "7.0.0-beta.44"
+			}
+		},
+		"node_modules/@babel/template/node_modules/@babel/highlight": {
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
+			"integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^2.0.0",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.0"
+			}
+		},
+		"node_modules/@babel/template/node_modules/js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+			"dev": true
+		},
+		"node_modules/@babel/traverse": {
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.44.tgz",
+			"integrity": "sha512-UHuDz8ukQkJCDASKHf+oDt3FVUzFd+QYfuBIsiNu/4+/ix6pP/C+uQZJ6K1oEfbCMv/IKWbgDEh7fcsnIE5AtA==",
+			"dev": true,
+			"dependencies": {
+				"@babel/code-frame": "7.0.0-beta.44",
+				"@babel/generator": "7.0.0-beta.44",
+				"@babel/helper-function-name": "7.0.0-beta.44",
+				"@babel/helper-split-export-declaration": "7.0.0-beta.44",
+				"@babel/types": "7.0.0-beta.44",
+				"babylon": "7.0.0-beta.44",
+				"debug": "^3.1.0",
+				"globals": "^11.1.0",
+				"invariant": "^2.2.0",
+				"lodash": "^4.2.0"
+			}
+		},
+		"node_modules/@babel/traverse/node_modules/@babel/code-frame": {
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
+			"integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
+			"dev": true,
+			"dependencies": {
+				"@babel/highlight": "7.0.0-beta.44"
+			}
+		},
+		"node_modules/@babel/traverse/node_modules/@babel/highlight": {
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
+			"integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^2.0.0",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.0"
+			}
+		},
+		"node_modules/@babel/traverse/node_modules/js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+			"dev": true
+		},
+		"node_modules/@babel/types": {
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
+			"integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
+			"dev": true,
+			"dependencies": {
+				"esutils": "^2.0.2",
+				"lodash": "^4.2.0",
+				"to-fast-properties": "^2.0.0"
+			}
+		},
+		"node_modules/@types/estree": {
+			"version": "0.0.50",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
+			"integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
+		},
+		"node_modules/@types/node": {
+			"version": "12.12.7",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.7.tgz",
+			"integrity": "sha512-E6Zn0rffhgd130zbCbAr/JdXfXkoOUFAKNs/rF8qnafSJ8KYaA/j3oz7dcwal+lYjLA7xvdd5J4wdYpCTlP8+w==",
+			"dev": true
+		},
+		"node_modules/acorn": {
+			"version": "8.0.5",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.0.5.tgz",
+			"integrity": "sha512-v+DieK/HJkJOpFBETDJioequtc3PfxsWMaxIdIwujtF7FEV/MAyDQLlm6/zPvr7Mix07mLh6ccVwIsloceodlg==",
+			"bin": {
+				"acorn": "bin/acorn"
+			},
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
+		"node_modules/ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
+			"dependencies": {
+				"color-convert": "^1.9.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/babel-eslint": {
+			"version": "8.2.6",
+			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.6.tgz",
+			"integrity": "sha512-aCdHjhzcILdP8c9lej7hvXKvQieyRt20SF102SIGyY4cUIiw6UaAtK4j2o3dXX74jEmy0TJ0CEhv4fTIM3SzcA==",
+			"deprecated": "babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.",
+			"dev": true,
+			"dependencies": {
+				"@babel/code-frame": "7.0.0-beta.44",
+				"@babel/traverse": "7.0.0-beta.44",
+				"@babel/types": "7.0.0-beta.44",
+				"babylon": "7.0.0-beta.44",
+				"eslint-scope": "3.7.1",
+				"eslint-visitor-keys": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/babel-eslint/node_modules/@babel/code-frame": {
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
+			"integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
+			"dev": true,
+			"dependencies": {
+				"@babel/highlight": "7.0.0-beta.44"
+			}
+		},
+		"node_modules/babel-eslint/node_modules/@babel/highlight": {
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
+			"integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
+			"dev": true,
+			"dependencies": {
+				"chalk": "^2.0.0",
+				"esutils": "^2.0.2",
+				"js-tokens": "^3.0.0"
+			}
+		},
+		"node_modules/babel-eslint/node_modules/js-tokens": {
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+			"dev": true
+		},
+		"node_modules/babylon": {
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+			"integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
+			"dev": true,
+			"bin": {
+				"babylon": "bin/babylon.js"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
+		},
+		"node_modules/chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
+			"dependencies": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
+			"dependencies": {
+				"color-name": "1.1.3"
+			}
+		},
+		"node_modules/color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
+		},
+		"node_modules/debug": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"dev": true,
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"node_modules/deep-is": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
+		},
+		"node_modules/dequal": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
+			"integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/esbuild": {
+			"version": "0.11.16",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.11.16.tgz",
+			"integrity": "sha512-34ZWjo4ouvM5cDe7uRoM9GFuMyEmpH9fnVYmomvS1cq9ED9d/0ZG1r+p4P2VbX7ihjv36zA2SWTmP8Zmt/EANA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"bin": {
+				"esbuild": "bin/esbuild"
+			}
+		},
+		"node_modules/escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.8.0"
+			}
+		},
+		"node_modules/eslint-scope": {
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+			"dev": true,
+			"dependencies": {
+				"esrecurse": "^4.1.0",
+				"estraverse": "^4.1.1"
+			},
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
+		"node_modules/eslint-visitor-keys": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+			"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/eslump": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/eslump/-/eslump-2.0.0.tgz",
+			"integrity": "sha512-80p4ogK1rh8LWyTIRAeL4BEC1sSP0O/8JYNygSvLQXN0+zhKlTtRsESOsBUU+POHNISTifbefaEJNqpqZQxdKQ==",
+			"dev": true,
+			"dependencies": {
+				"@babel/code-frame": "^7.0.0",
+				"mkdirp": "^0.5.1",
+				"optionator": "^0.8.2",
+				"random-int": "^1.0.0",
+				"random-item": "^1.0.0",
+				"shift-codegen": "5.1.0",
+				"shift-fuzzer": "^1.0.2",
+				"shift-reducer": "^5.0.0"
+			},
+			"bin": {
+				"eslump": "src/cli-runner.js"
+			}
+		},
+		"node_modules/esrecurse": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+			"dev": true,
+			"dependencies": {
+				"estraverse": "^4.1.0"
+			},
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/estraverse": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+			"dev": true,
+			"engines": {
+				"node": ">=4.0"
+			}
+		},
+		"node_modules/estree-walker": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.0.tgz",
+			"integrity": "sha512-s6ceX0NFiU/vKPiKvFdR83U1Zffu7upwZsGwpoqfg5rbbq1l50WQ5hCeIvM6E6oD4shUHCYMsiFPns4Jk0YfMQ=="
+		},
+		"node_modules/esutils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
+		},
+		"node_modules/globals": {
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/invariant": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+			"dev": true,
+			"dependencies": {
+				"loose-envify": "^1.0.0"
+			}
+		},
+		"node_modules/is-reference": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.0.tgz",
+			"integrity": "sha512-Eo1W3wUoHWoCoVM4GVl/a+K0IgiqE5aIo4kJABFyMum1ZORlPkC+UC357sSQUL5w5QCE5kCC9upl75b7+7CY/Q==",
+			"dependencies": {
+				"@types/estree": "*"
+			}
+		},
+		"node_modules/js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true
+		},
+		"node_modules/jsesc": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+			"dev": true,
+			"bin": {
+				"jsesc": "bin/jsesc"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/kleur": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
+			"integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/levn": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"dev": true,
+			"dependencies": {
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/lodash": {
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"dev": true
+		},
+		"node_modules/loose-envify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"dev": true,
+			"dependencies": {
+				"js-tokens": "^3.0.0 || ^4.0.0"
+			},
+			"bin": {
+				"loose-envify": "cli.js"
+			}
+		},
+		"node_modules/minimist": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+			"dev": true
+		},
+		"node_modules/mkdirp": {
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+			"dev": true,
+			"dependencies": {
+				"minimist": "^1.2.5"
+			},
+			"bin": {
+				"mkdirp": "bin/cmd.js"
+			}
+		},
+		"node_modules/mri": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/mri/-/mri-1.1.6.tgz",
+			"integrity": "sha512-oi1b3MfbyGa7FJMP9GmLTttni5JoICpYBRlq+x5V16fZbLsnL9N3wFqqIm/nIG43FjUFkFh9Epzp/kzUGUnJxQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
+		},
+		"node_modules/object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/optionator": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"dev": true,
+			"dependencies": {
+				"deep-is": "~0.1.3",
+				"fast-levenshtein": "~2.0.4",
+				"levn": "~0.3.0",
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2",
+				"wordwrap": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/periscopic": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.0.4.tgz",
+			"integrity": "sha512-SFx68DxCv0Iyo6APZuw/AKewkkThGwssmU0QWtTlvov3VAtPX+QJ4CadwSaz8nrT5jPIuxdvJWB4PnD2KNDxQg==",
+			"dependencies": {
+				"estree-walker": "^3.0.0",
+				"is-reference": "^3.0.0"
+			}
+		},
+		"node_modules/prelude-ls": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"dev": true,
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/random-int": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/random-int/-/random-int-1.0.0.tgz",
+			"integrity": "sha1-5qLtNEisnGZGoGV0Q7HBUhWS7Qg=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/random-item": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/random-item/-/random-item-1.0.0.tgz",
+			"integrity": "sha1-Fu4xYmywUMihaGpfD0KmuZoqrxE=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/sade": {
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/sade/-/sade-1.7.4.tgz",
+			"integrity": "sha512-y5yauMD93rX840MwUJr7C1ysLFBgMspsdTo4UVrDg3fXDvtwOyIqykhVAAm6fk/3au77773itJStObgK+LKaiA==",
+			"dev": true,
+			"dependencies": {
+				"mri": "^1.1.0"
+			},
+			"engines": {
+				"node": ">= 6"
+			}
+		},
+		"node_modules/shift-ast": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/shift-ast/-/shift-ast-4.0.0.tgz",
+			"integrity": "sha1-HUFSoq3ShkSlKusuDIfYkl09l/8=",
+			"dev": true
+		},
+		"node_modules/shift-codegen": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/shift-codegen/-/shift-codegen-5.1.0.tgz",
+			"integrity": "sha512-OpRpMYukx4uNyZl+4j192qlghA+orUuXQwCxGB4C7XWVCeFOoz9MVCAQ9XNMQqeZKHE9YNoMpBA/kzrVUFpqcQ==",
+			"dev": true,
+			"dependencies": {
+				"babel-eslint": "^8.2.2",
+				"esutils": "^2.0.2",
+				"object-assign": "^4.1.0",
+				"shift-reducer": "^4.3.0"
+			}
+		},
+		"node_modules/shift-codegen/node_modules/shift-reducer": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/shift-reducer/-/shift-reducer-4.4.1.tgz",
+			"integrity": "sha512-IJmk9grLnuO8vLSG5e52wFXaDLXJmVMGPXKQljhh/Pwb1mQL8OgCr6c4OYyIa3OInTH9rBtms3SwDFWsJzVEnA==",
+			"dev": true,
+			"dependencies": {
+				"shift-ast": "^4.0.0"
+			}
+		},
+		"node_modules/shift-fuzzer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/shift-fuzzer/-/shift-fuzzer-1.0.2.tgz",
+			"integrity": "sha1-g7uuFHv2Aiqupyc+LiviJamZVys=",
+			"dev": true,
+			"dependencies": {
+				"shift-ast": "^4.0.0"
+			}
+		},
+		"node_modules/shift-reducer": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/shift-reducer/-/shift-reducer-5.0.0.tgz",
+			"integrity": "sha512-Jgr6kPMZuzsQ63NdeLJT6BZvtJ6IDbYFBVqiid1bZlwxeJYq81Cj2Wc4UUERjO4Q9tz5U4KpWaZhitjcBvfiYA==",
+			"dev": true,
+			"dependencies": {
+				"shift-ast": "5.0.0"
+			}
+		},
+		"node_modules/shift-reducer/node_modules/shift-ast": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/shift-ast/-/shift-ast-5.0.0.tgz",
+			"integrity": "sha512-kMhr/GwgrQ1U2kaa50sD5YxNDQEZHAZigVwrf/NNeezb6oiYnpPMV8v1WVRhCW8sjI7xUdzuPujSQ3gA2IuUAQ==",
+			"dev": true
+		},
+		"node_modules/source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/sourcemap-codec": {
+			"version": "1.4.8",
+			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+		},
+		"node_modules/supports-color": {
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+			"dev": true,
+			"dependencies": {
+				"has-flag": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/totalist": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/totalist/-/totalist-2.0.0.tgz",
+			"integrity": "sha512-+Y17F0YzxfACxTyjfhnJQEe7afPA0GSpYlFkl2VFMxYP7jshQf9gXV7cH47EfToBumFThfKBvfAcoUn6fdNeRQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/trim-right": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+			"dev": true,
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/type-check": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"dev": true,
+			"dependencies": {
+				"prelude-ls": "~1.1.2"
+			},
+			"engines": {
+				"node": ">= 0.8.0"
+			}
+		},
+		"node_modules/typescript": {
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
+			"integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==",
+			"dev": true,
+			"bin": {
+				"tsc": "bin/tsc",
+				"tsserver": "bin/tsserver"
+			},
+			"engines": {
+				"node": ">=4.2.0"
+			}
+		},
+		"node_modules/uvu": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.1.tgz",
+			"integrity": "sha512-JGxttnOGDFs77FaZ0yMUHIzczzQ5R1IlDeNW6Wymw6gAscwMdAffVOP6TlxLIfReZyK8tahoGwWZaTCJzNFDkg==",
+			"dev": true,
+			"dependencies": {
+				"dequal": "^2.0.0",
+				"diff": "^5.0.0",
+				"kleur": "^4.0.3",
+				"sade": "^1.7.3",
+				"totalist": "^2.0.0"
+			},
+			"bin": {
+				"uvu": "bin.js"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/uvu/node_modules/diff": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+			"integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
+		"node_modules/wordwrap": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+			"dev": true
+		}
+	},
+	"dependencies": {
+		"@babel/code-frame": {
+			"version": "7.5.5",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
+			"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+			"dev": true,
+			"requires": {
+				"@babel/highlight": "^7.0.0"
+			}
+		},
+		"@babel/generator": {
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.44.tgz",
+			"integrity": "sha512-5xVb7hlhjGcdkKpMXgicAVgx8syK5VJz193k0i/0sLP6DzE6lRrU1K3B/rFefgdo9LPGMAOOOAWW4jycj07ShQ==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "7.0.0-beta.44",
+				"jsesc": "^2.5.1",
+				"lodash": "^4.2.0",
+				"source-map": "^0.5.0",
+				"trim-right": "^1.0.1"
+			}
+		},
+		"@babel/helper-function-name": {
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
+			"integrity": "sha512-MHRG2qZMKMFaBavX0LWpfZ2e+hLloT++N7rfM3DYOMUOGCD8cVjqZpwiL8a0bOX3IYcQev1ruciT0gdFFRTxzg==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-get-function-arity": "7.0.0-beta.44",
+				"@babel/template": "7.0.0-beta.44",
+				"@babel/types": "7.0.0-beta.44"
+			}
+		},
+		"@babel/helper-get-function-arity": {
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
+			"integrity": "sha512-w0YjWVwrM2HwP6/H3sEgrSQdkCaxppqFeJtAnB23pRiJB5E/O9Yp7JAAeWBl+gGEgmBFinnTyOv2RN7rcSmMiw==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "7.0.0-beta.44"
+			}
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
+			"integrity": "sha512-aQ7QowtkgKKzPGf0j6u77kBMdUFVBKNHw2p/3HX/POt5/oz8ec5cs0GwlgM8Hz7ui5EwJnzyfRmkNF1Nx1N7aA==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "7.0.0-beta.44"
+			}
+		},
+		"@babel/highlight": {
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
+			"integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
+			"dev": true,
+			"requires": {
+				"chalk": "^2.0.0",
+				"esutils": "^2.0.2",
+				"js-tokens": "^4.0.0"
+			}
+		},
+		"@babel/template": {
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
+			"integrity": "sha512-w750Sloq0UNifLx1rUqwfbnC6uSUk0mfwwgGRfdLiaUzfAOiH0tHJE6ILQIUi3KYkjiCDTskoIsnfqZvWLBDng==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "7.0.0-beta.44",
+				"@babel/types": "7.0.0-beta.44",
+				"babylon": "7.0.0-beta.44",
+				"lodash": "^4.2.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0-beta.44",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
+					"integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "7.0.0-beta.44"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.0.0-beta.44",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
+					"integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^3.0.0"
+					}
+				},
+				"js-tokens": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.44.tgz",
+			"integrity": "sha512-UHuDz8ukQkJCDASKHf+oDt3FVUzFd+QYfuBIsiNu/4+/ix6pP/C+uQZJ6K1oEfbCMv/IKWbgDEh7fcsnIE5AtA==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "7.0.0-beta.44",
+				"@babel/generator": "7.0.0-beta.44",
+				"@babel/helper-function-name": "7.0.0-beta.44",
+				"@babel/helper-split-export-declaration": "7.0.0-beta.44",
+				"@babel/types": "7.0.0-beta.44",
+				"babylon": "7.0.0-beta.44",
+				"debug": "^3.1.0",
+				"globals": "^11.1.0",
+				"invariant": "^2.2.0",
+				"lodash": "^4.2.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0-beta.44",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
+					"integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "7.0.0-beta.44"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.0.0-beta.44",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
+					"integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^3.0.0"
+					}
+				},
+				"js-tokens": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+					"dev": true
+				}
+			}
+		},
+		"@babel/types": {
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
+			"integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
+			"dev": true,
+			"requires": {
+				"esutils": "^2.0.2",
+				"lodash": "^4.2.0",
+				"to-fast-properties": "^2.0.0"
+			}
+		},
+		"@types/estree": {
+			"version": "0.0.50",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.50.tgz",
+			"integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
+		},
+		"@types/node": {
+			"version": "12.12.7",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.7.tgz",
+			"integrity": "sha512-E6Zn0rffhgd130zbCbAr/JdXfXkoOUFAKNs/rF8qnafSJ8KYaA/j3oz7dcwal+lYjLA7xvdd5J4wdYpCTlP8+w==",
+			"dev": true
+		},
+		"acorn": {
+			"version": "8.0.5",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.0.5.tgz",
+			"integrity": "sha512-v+DieK/HJkJOpFBETDJioequtc3PfxsWMaxIdIwujtF7FEV/MAyDQLlm6/zPvr7Mix07mLh6ccVwIsloceodlg=="
+		},
+		"ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"dev": true,
+			"requires": {
+				"color-convert": "^1.9.0"
+			}
+		},
+		"babel-eslint": {
+			"version": "8.2.6",
+			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.6.tgz",
+			"integrity": "sha512-aCdHjhzcILdP8c9lej7hvXKvQieyRt20SF102SIGyY4cUIiw6UaAtK4j2o3dXX74jEmy0TJ0CEhv4fTIM3SzcA==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "7.0.0-beta.44",
+				"@babel/traverse": "7.0.0-beta.44",
+				"@babel/types": "7.0.0-beta.44",
+				"babylon": "7.0.0-beta.44",
+				"eslint-scope": "3.7.1",
+				"eslint-visitor-keys": "^1.0.0"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.0.0-beta.44",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
+					"integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
+					"dev": true,
+					"requires": {
+						"@babel/highlight": "7.0.0-beta.44"
+					}
+				},
+				"@babel/highlight": {
+					"version": "7.0.0-beta.44",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
+					"integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
+					"dev": true,
+					"requires": {
+						"chalk": "^2.0.0",
+						"esutils": "^2.0.2",
+						"js-tokens": "^3.0.0"
+					}
+				},
+				"js-tokens": {
+					"version": "3.0.2",
+					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+					"dev": true
+				}
+			}
+		},
+		"babylon": {
+			"version": "7.0.0-beta.44",
+			"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
+			"integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
+			"dev": true
+		},
+		"chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"dev": true,
+			"requires": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			}
+		},
+		"color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"dev": true,
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"dev": true
+		},
+		"debug": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"dev": true,
+			"requires": {
+				"ms": "2.0.0"
+			}
+		},
+		"deep-is": {
+			"version": "0.1.3",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
+		},
+		"dequal": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
+			"integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==",
+			"dev": true
+		},
+		"esbuild": {
+			"version": "0.11.16",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.11.16.tgz",
+			"integrity": "sha512-34ZWjo4ouvM5cDe7uRoM9GFuMyEmpH9fnVYmomvS1cq9ED9d/0ZG1r+p4P2VbX7ihjv36zA2SWTmP8Zmt/EANA==",
+			"dev": true
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
+		},
+		"eslint-scope": {
+			"version": "3.7.1",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+			"dev": true,
+			"requires": {
+				"esrecurse": "^4.1.0",
+				"estraverse": "^4.1.1"
+			}
+		},
+		"eslint-visitor-keys": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
+			"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+			"dev": true
+		},
+		"eslump": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/eslump/-/eslump-2.0.0.tgz",
+			"integrity": "sha512-80p4ogK1rh8LWyTIRAeL4BEC1sSP0O/8JYNygSvLQXN0+zhKlTtRsESOsBUU+POHNISTifbefaEJNqpqZQxdKQ==",
+			"dev": true,
+			"requires": {
+				"@babel/code-frame": "^7.0.0",
+				"mkdirp": "^0.5.1",
+				"optionator": "^0.8.2",
+				"random-int": "^1.0.0",
+				"random-item": "^1.0.0",
+				"shift-codegen": "5.1.0",
+				"shift-fuzzer": "^1.0.2",
+				"shift-reducer": "^5.0.0"
+			}
+		},
+		"esrecurse": {
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+			"dev": true,
+			"requires": {
+				"estraverse": "^4.1.0"
+			}
+		},
+		"estraverse": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
+			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+			"dev": true
+		},
+		"estree-walker": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.0.tgz",
+			"integrity": "sha512-s6ceX0NFiU/vKPiKvFdR83U1Zffu7upwZsGwpoqfg5rbbq1l50WQ5hCeIvM6E6oD4shUHCYMsiFPns4Jk0YfMQ=="
+		},
+		"esutils": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"dev": true
+		},
+		"fast-levenshtein": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
+		},
+		"globals": {
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+			"dev": true
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
+		},
+		"invariant": {
+			"version": "2.2.4",
+			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+			"dev": true,
+			"requires": {
+				"loose-envify": "^1.0.0"
+			}
+		},
+		"is-reference": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.0.tgz",
+			"integrity": "sha512-Eo1W3wUoHWoCoVM4GVl/a+K0IgiqE5aIo4kJABFyMum1ZORlPkC+UC357sSQUL5w5QCE5kCC9upl75b7+7CY/Q==",
+			"requires": {
+				"@types/estree": "*"
+			}
+		},
+		"js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+			"dev": true
+		},
+		"jsesc": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+			"dev": true
+		},
+		"kleur": {
+			"version": "4.1.4",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
+			"integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
+			"dev": true
+		},
+		"levn": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"dev": true,
+			"requires": {
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2"
+			}
+		},
+		"lodash": {
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+			"dev": true
+		},
+		"loose-envify": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+			"dev": true,
+			"requires": {
+				"js-tokens": "^3.0.0 || ^4.0.0"
+			}
+		},
+		"minimist": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+			"dev": true
+		},
+		"mkdirp": {
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+			"dev": true,
+			"requires": {
+				"minimist": "^1.2.5"
+			}
+		},
+		"mri": {
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/mri/-/mri-1.1.6.tgz",
+			"integrity": "sha512-oi1b3MfbyGa7FJMP9GmLTttni5JoICpYBRlq+x5V16fZbLsnL9N3wFqqIm/nIG43FjUFkFh9Epzp/kzUGUnJxQ==",
+			"dev": true
+		},
+		"ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
+		},
+		"object-assign": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"dev": true
+		},
+		"optionator": {
+			"version": "0.8.2",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"dev": true,
+			"requires": {
+				"deep-is": "~0.1.3",
+				"fast-levenshtein": "~2.0.4",
+				"levn": "~0.3.0",
+				"prelude-ls": "~1.1.2",
+				"type-check": "~0.3.2",
+				"wordwrap": "~1.0.0"
+			}
+		},
+		"periscopic": {
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.0.4.tgz",
+			"integrity": "sha512-SFx68DxCv0Iyo6APZuw/AKewkkThGwssmU0QWtTlvov3VAtPX+QJ4CadwSaz8nrT5jPIuxdvJWB4PnD2KNDxQg==",
+			"requires": {
+				"estree-walker": "^3.0.0",
+				"is-reference": "^3.0.0"
+			}
+		},
+		"prelude-ls": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"dev": true
+		},
+		"random-int": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/random-int/-/random-int-1.0.0.tgz",
+			"integrity": "sha1-5qLtNEisnGZGoGV0Q7HBUhWS7Qg=",
+			"dev": true
+		},
+		"random-item": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/random-item/-/random-item-1.0.0.tgz",
+			"integrity": "sha1-Fu4xYmywUMihaGpfD0KmuZoqrxE=",
+			"dev": true
+		},
+		"sade": {
+			"version": "1.7.4",
+			"resolved": "https://registry.npmjs.org/sade/-/sade-1.7.4.tgz",
+			"integrity": "sha512-y5yauMD93rX840MwUJr7C1ysLFBgMspsdTo4UVrDg3fXDvtwOyIqykhVAAm6fk/3au77773itJStObgK+LKaiA==",
+			"dev": true,
+			"requires": {
+				"mri": "^1.1.0"
+			}
+		},
+		"shift-ast": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/shift-ast/-/shift-ast-4.0.0.tgz",
+			"integrity": "sha1-HUFSoq3ShkSlKusuDIfYkl09l/8=",
+			"dev": true
+		},
+		"shift-codegen": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/shift-codegen/-/shift-codegen-5.1.0.tgz",
+			"integrity": "sha512-OpRpMYukx4uNyZl+4j192qlghA+orUuXQwCxGB4C7XWVCeFOoz9MVCAQ9XNMQqeZKHE9YNoMpBA/kzrVUFpqcQ==",
+			"dev": true,
+			"requires": {
+				"babel-eslint": "^8.2.2",
+				"esutils": "^2.0.2",
+				"object-assign": "^4.1.0",
+				"shift-reducer": "^4.3.0"
+			},
+			"dependencies": {
+				"shift-reducer": {
+					"version": "4.4.1",
+					"resolved": "https://registry.npmjs.org/shift-reducer/-/shift-reducer-4.4.1.tgz",
+					"integrity": "sha512-IJmk9grLnuO8vLSG5e52wFXaDLXJmVMGPXKQljhh/Pwb1mQL8OgCr6c4OYyIa3OInTH9rBtms3SwDFWsJzVEnA==",
+					"dev": true,
+					"requires": {
+						"shift-ast": "^4.0.0"
+					}
+				}
+			}
+		},
+		"shift-fuzzer": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/shift-fuzzer/-/shift-fuzzer-1.0.2.tgz",
+			"integrity": "sha1-g7uuFHv2Aiqupyc+LiviJamZVys=",
+			"dev": true,
+			"requires": {
+				"shift-ast": "^4.0.0"
+			}
+		},
+		"shift-reducer": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/shift-reducer/-/shift-reducer-5.0.0.tgz",
+			"integrity": "sha512-Jgr6kPMZuzsQ63NdeLJT6BZvtJ6IDbYFBVqiid1bZlwxeJYq81Cj2Wc4UUERjO4Q9tz5U4KpWaZhitjcBvfiYA==",
+			"dev": true,
+			"requires": {
+				"shift-ast": "5.0.0"
+			},
+			"dependencies": {
+				"shift-ast": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/shift-ast/-/shift-ast-5.0.0.tgz",
+					"integrity": "sha512-kMhr/GwgrQ1U2kaa50sD5YxNDQEZHAZigVwrf/NNeezb6oiYnpPMV8v1WVRhCW8sjI7xUdzuPujSQ3gA2IuUAQ==",
+					"dev": true
+				}
+			}
+		},
+		"source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+			"dev": true
+		},
+		"sourcemap-codec": {
+			"version": "1.4.8",
+			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+		},
+		"supports-color": {
+			"version": "5.4.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+			"dev": true,
+			"requires": {
+				"has-flag": "^3.0.0"
+			}
+		},
+		"to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+			"dev": true
+		},
+		"totalist": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/totalist/-/totalist-2.0.0.tgz",
+			"integrity": "sha512-+Y17F0YzxfACxTyjfhnJQEe7afPA0GSpYlFkl2VFMxYP7jshQf9gXV7cH47EfToBumFThfKBvfAcoUn6fdNeRQ==",
+			"dev": true
+		},
+		"trim-right": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
+			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+			"dev": true
+		},
+		"type-check": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"dev": true,
+			"requires": {
+				"prelude-ls": "~1.1.2"
+			}
+		},
+		"typescript": {
+			"version": "3.7.2",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
+			"integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==",
+			"dev": true
+		},
+		"uvu": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.1.tgz",
+			"integrity": "sha512-JGxttnOGDFs77FaZ0yMUHIzczzQ5R1IlDeNW6Wymw6gAscwMdAffVOP6TlxLIfReZyK8tahoGwWZaTCJzNFDkg==",
+			"dev": true,
+			"requires": {
+				"dequal": "^2.0.0",
+				"diff": "^5.0.0",
+				"kleur": "^4.0.3",
+				"sade": "^1.7.3",
+				"totalist": "^2.0.0"
+			},
+			"dependencies": {
+				"diff": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+					"integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+					"dev": true
+				}
+			}
+		},
+		"wordwrap": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+			"dev": true
+		}
+	}
 }

--- a/src/print/handlers.js
+++ b/src/print/handlers.js
@@ -355,11 +355,7 @@ const handle_var_declaration = (node, state) => {
 
 	const separator = c(multiple_lines ? `,\n${state.indent}\t` : ', ');
 
-	if (multiple_lines) {
-		push_array(chunks, join(declarators, separator));
-	} else {
-		push_array(chunks, join(declarators, separator));
-	}
+	push_array(chunks, join(declarators, separator));
 
 	return chunks;
 };

--- a/src/print/handlers.js
+++ b/src/print/handlers.js
@@ -2,6 +2,7 @@
 // released under MIT license https://github.com/davidbonnet/astring/blob/master/LICENSE
 
 import { re } from '../utils/id.js';
+import { push_array } from '../utils/push_array.js';
 
 /** @typedef {import('estree').ArrowFunctionExpression} ArrowFunctionExpression */
 /** @typedef {import('estree').BinaryExpression} BinaryExpression */
@@ -248,7 +249,8 @@ const join = (nodes, separator) => {
 
 	const joined = [...nodes[0]];
 	for (let i = 1; i < nodes.length; i += 1) {
-		joined.push(separator, ...nodes[i]);
+		joined.push(separator);
+		push_array(joined, nodes[i]);
 	}
 	return joined;
 };
@@ -326,9 +328,7 @@ const handle_body = (nodes, state) => {
 			);
 		}
 
-		chunks.push(
-			...body[i]
-		);
+		push_array(chunks, body[i]);
 
 		needed_padding = needs_padding;
 	}
@@ -356,11 +356,9 @@ const handle_var_declaration = (node, state) => {
 	const separator = c(multiple_lines ? `,\n${state.indent}\t` : ', ');
 
 	if (multiple_lines) {
-		chunks.push(...join(declarators, separator));
+		push_array(chunks, join(declarators, separator));
 	} else {
-		chunks.push(
-			...join(declarators, separator)
-		);
+		push_array(chunks, join(declarators, separator));
 	}
 
 	return chunks;
@@ -416,10 +414,8 @@ const handlers = {
 		];
 
 		if (node.alternate) {
-			chunks.push(
-				c(' else '),
-				...handle(node.alternate, state)
-			);
+			chunks.push(c(' else '));
+			push_array(chunks, handle(node.alternate, state));
 		}
 
 		return chunks;
@@ -463,20 +459,16 @@ const handlers = {
 
 		node.cases.forEach(block => {
 			if (block.test) {
-				chunks.push(
-					c(`\n${state.indent}\tcase `),
-					...handle(block.test, { ...state, indent: `${state.indent}\t` }),
-					c(':')
-				);
+				chunks.push(c(`\n${state.indent}\tcase `));
+				push_array(chunks, handle(block.test, { ...state, indent: `${state.indent}\t` }));
+				chunks.push(c(':'));
 			} else {
 				chunks.push(c(`\n${state.indent}\tdefault:`))
 			}
 
 			block.consequent.forEach(statement => {
-				chunks.push(
-					c(`\n${state.indent}\t\t`),
-					...handle(statement, { ...state, indent: `${state.indent}\t\t` })
-				);
+				chunks.push(c(`\n${state.indent}\t\t`));
+				push_array(chunks, handle(statement, { ...state, indent: `${state.indent}\t\t` }));
 			});
 		});
 
@@ -514,20 +506,19 @@ const handlers = {
 
 		if (node.handler) {
 			if (node.handler.param) {
-				chunks.push(
-					c(' catch('),
-					...handle(node.handler.param, state),
-					c(') ')
-				);
+				chunks.push(c(' catch('));
+				push_array(chunks, handle(node.handler.param, state));
+				chunks.push(c(') '));
 			} else {
 				chunks.push(c(' catch '));
 			}
 
-			chunks.push(...handle(node.handler.body, state));
+			push_array(chunks, handle(node.handler.body, state));
 		}
 
 		if (node.finalizer) {
-			chunks.push(c(' finally '), ...handle(node.finalizer, state));
+			chunks.push(c(' finally '));
+			push_array(chunks, handle(node.finalizer, state));
 		}
 
 		return chunks;
@@ -557,21 +548,19 @@ const handlers = {
 
 		if (node.init) {
 			if (node.init.type === 'VariableDeclaration') {
-				chunks.push(...handle_var_declaration(node.init, state));
+				push_array(chunks, handle_var_declaration(node.init, state));
 			} else {
-				chunks.push(...handle(node.init, state));
+				push_array(chunks, handle(node.init, state));
 			}
 		}
 
 		chunks.push(c('; '));
-		if (node.test) chunks.push(...handle(node.test, state));
+		if (node.test) push_array(chunks, handle(node.test, state));
 		chunks.push(c('; '));
-		if (node.update) chunks.push(...handle(node.update, state));
+		if (node.update) push_array(chunks, handle(node.update, state));
 
-		chunks.push(
-			c(') '),
-			...handle(node.body, state)
-		);
+		chunks.push(c(') '));
+		push_array(chunks, handle(node.body, state));
 
 		return chunks;
 	}),
@@ -582,17 +571,15 @@ const handlers = {
 		];
 
 		if (node.left.type === 'VariableDeclaration') {
-			chunks.push(...handle_var_declaration(node.left, state));
+			push_array(chunks, handle_var_declaration(node.left, state));
 		} else {
-			chunks.push(...handle(node.left, state));
+			push_array(chunks, handle(node.left, state));
 		}
 
-		chunks.push(
-			c(node.type === 'ForInStatement' ? ` in ` : ` of `),
-			...handle(node.right, state),
-			c(') '),
-			...handle(node.body, state)
-		);
+		chunks.push(c(node.type === 'ForInStatement' ? ` in ` : ` of `));
+		push_array(chunks, handle(node.right, state));
+		chunks.push(c(') '));
+		push_array(chunks, handle(node.body, state));
 
 		return chunks;
 	}),
@@ -606,7 +593,7 @@ const handlers = {
 
 		if (node.async) chunks.push(c('async '));
 		chunks.push(c(node.generator ? 'function* ' : 'function '));
-		if (node.id) chunks.push(...handle(node.id, state));
+		if (node.id) push_array(chunks, handle(node.id, state));
 		chunks.push(c('('));
 
 		const params = node.params.map(p => handle(p, {
@@ -622,21 +609,15 @@ const handlers = {
 		const separator = c(multiple_lines ? `,\n${state.indent}` : ', ');
 
 		if (multiple_lines) {
-			chunks.push(
-				c(`\n${state.indent}\t`),
-				...join(params, separator),
-				c(`\n${state.indent}`)
-			);
+			chunks.push(c(`\n${state.indent}\t`));
+			push_array(chunks, join(params, separator));
+			chunks.push(c(`\n${state.indent}`));
 		} else {
-			chunks.push(
-				...join(params, separator)
-			);
+			push_array(chunks, join(params, separator));
 		}
 
-		chunks.push(
-			c(') '),
-			...handle(node.body, state)
-		);
+		chunks.push(c(') '));
+		push_array(chunks, handle(node.body, state));
 
 		return chunks;
 	}),
@@ -660,17 +641,18 @@ const handlers = {
 	ClassDeclaration(node, state) {
 		const chunks = [c('class ')];
 
-		if (node.id) chunks.push(...handle(node.id, state), c(' '));
-
-		if (node.superClass) {
-			chunks.push(
-				c('extends '),
-				...handle(node.superClass, state),
-				c(' ')
-			);
+		if (node.id) {
+			push_array(chunks, handle(node.id, state));
+			chunks.push(c(' '));
 		}
 
-		chunks.push(...handle(node.body, state));
+		if (node.superClass) {
+			chunks.push(c('extends '));
+			push_array(chunks, handle(node.superClass, state));
+			chunks.push(c(' '));
+		}
+
+		push_array(chunks, handle(node.body, state));
 
 		return chunks;
 	},
@@ -718,27 +700,21 @@ const handlers = {
 				const width = get_length(chunks) + specifiers.map(get_length).reduce(sum, 0) + (2 * specifiers.length) + 6 + get_length(source);
 
 				if (width > 80) {
-					chunks.push(
-						c(`{\n\t`),
-						...join(specifiers, c(',\n\t')),
-						c('\n}')
-					);
+					chunks.push(c(`{\n\t`));
+					push_array(chunks, join(specifiers, c(',\n\t')));
+					chunks.push(c('\n}'));
 				} else {
-					chunks.push(
-						c(`{ `),
-						...join(specifiers, c(', ')),
-						c(' }')
-					);
+					chunks.push(c(`{ `));
+					push_array(chunks, join(specifiers, c(', ')));
+					chunks.push(c(' }'));
 				}
 			}
 
 			chunks.push(c(' from '));
 		}
 
-		chunks.push(
-			...source,
-			c(';')
-		);
+		push_array(chunks, source);
+		chunks.push(c(';'));
 
 		return chunks;
 	},
@@ -764,7 +740,7 @@ const handlers = {
 		const chunks = [c('export ')];
 
 		if (node.declaration) {
-			chunks.push(...handle(node.declaration, state));
+			push_array(chunks, handle(node.declaration, state));
 		} else {
 			const specifiers = node.specifiers.map((/** @type {ExportSpecifier} */ specifier) => {
 				const name = handle(specifier.local, state)[0];
@@ -780,24 +756,18 @@ const handlers = {
 			const width = 7 + specifiers.map(get_length).reduce(sum, 0) + 2 * specifiers.length;
 
 			if (width > 80) {
-				chunks.push(
-					c('{\n\t'),
-					...join(specifiers, c(',\n\t')),
-					c('\n}')
-				);
+				chunks.push(c('{\n\t'));
+				push_array(chunks, join(specifiers, c(',\n\t')));
+				chunks.push(c('\n}'));
 			} else {
-				chunks.push(
-					c('{ '),
-					...join(specifiers, c(', ')),
-					c(' }')
-				);
+				chunks.push(c('{ '));
+				push_array(chunks, join(specifiers, c(', ')));
+				chunks.push(c(' }'));
 			}
 
 			if (node.source) {
-				chunks.push(
-					c(' from '),
-					...handle(node.source, state)
-				);
+				chunks.push(c(' from '));
+				push_array(chunks, handle(node.source, state));
 			}
 		}
 
@@ -835,27 +805,23 @@ const handlers = {
 		}
 
 		if (node.computed) {
-			chunks.push(
-				c('['),
-				...handle(node.key, state),
-				c(']')
-			);
+			chunks.push(c('['));
+			push_array(chunks, handle(node.key, state));
+			chunks.push(c(']'));
 		} else {
-			chunks.push(...handle(node.key, state));
+			push_array(chunks, handle(node.key, state));
 		}
 
 		chunks.push(c('('));
 
 		const { params } = node.value;
 		for (let i = 0; i < params.length; i += 1) {
-			chunks.push(...handle(params[i], state));
+			push_array(chunks, handle(params[i], state));
 			if (i < params.length - 1) chunks.push(c(', '));
 		}
 
-		chunks.push(
-			c(') '),
-			...handle(node.value.body, state)
-		);
+		chunks.push(c(') '));
+		push_array(chunks, handle(node.value.body, state));
 
 		return chunks;
 	},
@@ -866,18 +832,16 @@ const handlers = {
 		if (node.async) chunks.push(c('async '));
 
 		if (node.params.length === 1 && node.params[0].type === 'Identifier') {
-			chunks.push(...handle(node.params[0], state));
+			push_array(chunks, handle(node.params[0], state));
 		} else {
 			const params = node.params.map(param => handle(param, {
 				...state,
 				indent: state.indent + '\t'
 			}));
 
-			chunks.push(
-				c('('),
-				...join(params, c(', ')),
-				c(')')
-			);
+			chunks.push(c('('));
+			push_array(chunks, join(params, c(', ')));
+			chunks.push(c(')'));
 		}
 
 		chunks.push(c(' => '));
@@ -886,13 +850,11 @@ const handlers = {
 			node.body.type === 'ObjectExpression' ||
 			(node.body.type === 'AssignmentExpression' && node.body.left.type === 'ObjectPattern')
 		) {
-			chunks.push(
-				c('('),
-				...handle(node.body, state),
-				c(')')
-			);
+			chunks.push(c('('));
+			push_array(chunks, handle(node.body, state));
+			chunks.push(c(')'));
 		} else {
-			chunks.push(...handle(node.body, state));
+			push_array(chunks, handle(node.body, state));
 		}
 
 		return chunks;
@@ -940,10 +902,10 @@ const handlers = {
 		for (let i = 0; i < expressions.length; i++) {
 			chunks.push(
 				c(quasis[i].value.raw),
-				c('${'),
-				...handle(expressions[i], state),
-				c('}')
+				c('${')
 			);
+			push_array(chunks, handle(expressions[i], state));
+			chunks.push(c('}'));
 		}
 
 		chunks.push(
@@ -987,14 +949,13 @@ const handlers = {
 		);
 
 		if (multiple_lines) {
-			chunks.push(
-				c(`\n${state.indent}\t`),
-				...join(elements, c(`,\n${state.indent}\t`)),
-				c(`\n${state.indent}`),
-				...sparse_commas
-			);
+			chunks.push(c(`\n${state.indent}\t`));
+			push_array(chunks, join(elements, c(`,\n${state.indent}\t`)));
+			chunks.push(c(`\n${state.indent}`));
+			push_array(chunks, sparse_commas);
 		} else {
-			chunks.push(...join(elements, c(', ')), ...sparse_commas);
+			push_array(chunks, join(elements, c(', ')));
+			push_array(chunks, sparse_commas);
 		}
 
 		chunks.push(c(']'));
@@ -1014,7 +975,7 @@ const handlers = {
 		const separator = c(', ');
 
 		node.properties.forEach((p, i) => {
-			chunks.push(...handle(p, {
+			push_array(chunks, handle(p, {
 				...state,
 				indent: state.indent + '\t'
 			}));
@@ -1102,13 +1063,11 @@ const handlers = {
 				chunks.push(c('*'));
 			}
 
-			chunks.push(
-				...(node.computed ? [c('['), ...key, c(']')] : key),
-				c('('),
-				...join(node.value.params.map((/** @type {Pattern} */ param) => handle(param, state)), c(', ')),
-				c(') '),
-				...handle(node.value.body, state)
-			);
+			push_array(chunks, node.computed ? [c('['), ...key, c(']')] : key);
+			chunks.push(c('('));
+			push_array(chunks, join(node.value.params.map((/** @type {Pattern} */ param) => handle(param, state)), c(', ')));
+			chunks.push(c(') '));
+			push_array(chunks, handle(node.value.body, state));
 
 			return chunks;
 		}
@@ -1133,7 +1092,7 @@ const handlers = {
 		const chunks = [c('{ ')];
 
 		for (let i = 0; i < node.properties.length; i += 1) {
-			chunks.push(...handle(node.properties[i], state));
+			push_array(chunks, handle(node.properties[i], state));
 			if (i < node.properties.length - 1) chunks.push(c(', '));
 		}
 
@@ -1163,13 +1122,11 @@ const handlers = {
 			EXPRESSIONS_PRECEDENCE[node.argument.type] <
 			EXPRESSIONS_PRECEDENCE.UnaryExpression
 		) {
-			chunks.push(
-				c('('),
-				...handle(node.argument, state),
-				c(')')
-			);
+			chunks.push(c('('));
+			push_array(chunks, handle(node.argument, state));
+			chunks.push(c(')'));
 		} else {
-			chunks.push(...handle(node.argument, state));
+			push_array(chunks, handle(node.argument, state));
 		}
 
 		return chunks;
@@ -1190,6 +1147,9 @@ const handlers = {
 	},
 
 	BinaryExpression(node, state) {
+		/**
+		 * @type any[]
+		 */
 		const chunks = [];
 
 		// TODO
@@ -1200,44 +1160,41 @@ const handlers = {
 		// }
 
 		if (needs_parens(node.left, node, false)) {
-			chunks.push(
-				c('('),
-				...handle(node.left, state),
-				c(')')
-			);
+			chunks.push(c('('));
+			push_array(chunks, handle(node.left, state));
+			chunks.push(c(')'));
 		} else {
-			chunks.push(...handle(node.left, state));
+			push_array(chunks, handle(node.left, state));
 		}
 
 		chunks.push(c(` ${node.operator} `));
 
 		if (needs_parens(node.right, node, true)) {
-			chunks.push(
-				c('('),
-				...handle(node.right, state),
-				c(')')
-			);
+			chunks.push(c('('));
+			push_array(chunks, handle(node.right, state));
+			chunks.push(c(')'));
 		} else {
-			chunks.push(...handle(node.right, state));
+			push_array(chunks, handle(node.right, state));
 		}
 
 		return chunks;
 	},
 
 	ConditionalExpression(node, state) {
+		/**
+		 * @type any[]
+		 */
 		const chunks = [];
 
 		if (
 			EXPRESSIONS_PRECEDENCE[node.test.type] >
 			EXPRESSIONS_PRECEDENCE.ConditionalExpression
 		) {
-			chunks.push(...handle(node.test, state));
+			push_array(chunks, handle(node.test, state));
 		} else {
-			chunks.push(
-				c('('),
-				...handle(node.test, state),
-				c(')')
-			);
+			chunks.push(c('('));
+			push_array(chunks, handle(node.test, state));
+			chunks.push(c(')'));
 		}
 
 		const child_state = { ...state, indent: state.indent + '\t' };
@@ -1251,19 +1208,15 @@ const handlers = {
 		);
 
 		if (multiple_lines) {
-			chunks.push(
-				c(`\n${state.indent}? `),
-				...consequent,
-				c(`\n${state.indent}: `),
-				...alternate
-			);
+			chunks.push(c(`\n${state.indent}? `));
+			push_array(chunks, consequent);
+			chunks.push(c(`\n${state.indent}: `));
+			push_array(chunks, alternate);
 		} else {
-			chunks.push(
-				c(` ? `),
-				...consequent,
-				c(` : `),
-				...alternate
-			);
+			chunks.push(c(` ? `));
+			push_array(chunks, consequent);
+			chunks.push(c(` : `));
+			push_array(chunks, alternate);
 		}
 
 		return chunks;
@@ -1276,13 +1229,11 @@ const handlers = {
 			EXPRESSIONS_PRECEDENCE[node.callee.type] <
 			EXPRESSIONS_PRECEDENCE.CallExpression || has_call_expression(node.callee)
 		) {
-			chunks.push(
-				c('('),
-				...handle(node.callee, state),
-				c(')')
-			)
+			chunks.push(c('('));
+			push_array(chunks, handle(node.callee, state));
+			chunks.push(c(')'));
 		} else {
-			chunks.push(...handle(node.callee, state));
+			push_array(chunks, handle(node.callee, state));
 		}
 
 		// TODO this is copied from CallExpression — DRY it out
@@ -1295,11 +1246,9 @@ const handlers = {
 			? c(',\n' + state.indent)
 			: c(', ');
 
-		chunks.push(
-			c('('),
-			...join(args, separator),
-			c(')')
-		);
+		chunks.push(c('('));
+		push_array(chunks, join(args, separator));
+		chunks.push(c(')'));
 
 		return chunks;
 	},
@@ -1309,19 +1258,20 @@ const handlers = {
 	},
 
 	CallExpression(/** @type {CallExpression} */ node, state) {
+		/**
+		 * @type any[]
+		 */
 		const chunks = [];
 
 		if (
 			EXPRESSIONS_PRECEDENCE[node.callee.type] <
 			EXPRESSIONS_PRECEDENCE.CallExpression
 		) {
-			chunks.push(
-				c('('),
-				...handle(node.callee, state),
-				c(')')
-			);
+			chunks.push(c('('));
+			push_array(chunks, handle(node.callee, state));
+			chunks.push(c(')'));
 		} else {
-			chunks.push(...handle(node.callee, state));
+			push_array(chunks, handle(node.callee, state));
 		}
 
 		if (/** @type {SimpleCallExpression} */ (node).optional) {
@@ -1339,49 +1289,42 @@ const handlers = {
 				indent: `${state.indent}\t`
 			}));
 
-			chunks.push(
-				c(`(\n${state.indent}\t`),
-				...join(args, c(`,\n${state.indent}\t`)),
-				c(`\n${state.indent})`)
-			);
+			chunks.push(c(`(\n${state.indent}\t`));
+			push_array(chunks, join(args, c(`,\n${state.indent}\t`)));
+			chunks.push(c(`\n${state.indent})`));
 		} else {
-			chunks.push(
-				c('('),
-				...join(args, c(', ')),
-				c(')')
-			);
+			chunks.push(c('('));
+			push_array(chunks, join(args, c(', ')));
+			chunks.push(c(')'));
 		}
 
 		return chunks;
 	},
 
 	MemberExpression(node, state) {
+		/**
+		 * @type any[]
+		 */
 		const chunks = [];
 
 		if (EXPRESSIONS_PRECEDENCE[node.object.type] < EXPRESSIONS_PRECEDENCE.MemberExpression) {
-			chunks.push(
-				c('('),
-				...handle(node.object, state),
-				c(')')
-			);
+			chunks.push(c('('));
+			push_array(chunks, handle(node.object, state));
+			chunks.push(c(')'));
 		} else {
-			chunks.push(...handle(node.object, state));
+			push_array(chunks, handle(node.object, state));
 		}
 
 		if (node.computed) {
 			if (node.optional) {
 				chunks.push(c('?.'));
 			}
-			chunks.push(
-				c('['),
-				...handle(node.property, state),
-				c(']')
-			);
+			chunks.push(c('['));
+			push_array(chunks, handle(node.property, state));
+			chunks.push(c(']'));
 		} else {
-			chunks.push(
-				c(node.optional ? '?.' : '.'),
-				...handle(node.property, state)
-			);
+			chunks.push(c(node.optional ? '?.' : '.'));
+			push_array(chunks, handle(node.property, state));
 		}
 
 		return chunks;

--- a/src/utils/push_array.js
+++ b/src/utils/push_array.js
@@ -1,14 +1,12 @@
 /**
- * Does `array.push` for all `items`.
- * Needed because `array.push(...items)` throws
- * "Maximum call stack size exceeded" when items
- * is too big of an array
+ * Does `array.push` for all `items`. Needed because `array.push(...items)` throws
+ * "Maximum call stack size exceeded" when `items` is too big of an array.
+ *
  * @param {any[]} array 
  * @param {any[]} items 
  */
- export function push_array(array, items) {
-    for (let i = 0; i < items.length; i++) {
-      array.push(items[i]);
-    }
-  };
-  
+export function push_array(array, items) {
+	for (let i = 0; i < items.length; i++) {
+		array.push(items[i]);
+	}
+};

--- a/src/utils/push_array.js
+++ b/src/utils/push_array.js
@@ -1,0 +1,14 @@
+/**
+ * Does `array.push` for all `items`.
+ * Needed because `array.push(...items)` throws
+ * "Maximum call stack size exceeded" when items
+ * is too big of an array
+ * @param {any[]} array 
+ * @param {any[]} items 
+ */
+ export function push_array(array, items) {
+    for (let i = 0; i < items.length; i++) {
+      array.push(items[i]);
+    }
+  };
+  


### PR DESCRIPTION
As discussed in the maintainers meeting, this just introduces a simple `push_array` method

Fixes #40
Alternative to / closes #64
Part of sveltejs/svelte#4694

Credit to @milahu for finding the issue, we should add a "co-authored by"-message to the merge.