### PR TITLE
chore: switch to @jridgewell/sourcemap-codec

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,183 +1,67 @@
 {
 	"name": "code-red",
-	"version": "0.2.4",
+	"version": "0.2.5",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "code-red",
-			"version": "0.2.4",
+			"version": "0.2.5",
 			"license": "MIT",
 			"dependencies": {
-				"@types/estree": "^0.0.50",
+				"@jridgewell/sourcemap-codec": "^1.4.14",
 				"acorn": "^8.0.5",
 				"estree-walker": "^3.0.0",
-				"is-reference": "^3.0.0",
-				"periscopic": "^3.0.4",
-				"sourcemap-codec": "^1.4.8"
+				"periscopic": "^3.0.4"
 			},
 			"devDependencies": {
+				"@types/estree": "^0.0.50",
 				"@types/node": "^12.12.7",
 				"esbuild": "^0.11.16",
-				"eslump": "^2.0.0",
+				"eslump": "^3.0.0",
 				"typescript": "^3.7.2",
-				"uvu": "^0.5.1"
+				"uvu": "^0.5.6"
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-			"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+			"integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
 			"dev": true,
 			"dependencies": {
-				"@babel/highlight": "^7.0.0"
+				"@babel/highlight": "^7.18.6"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@babel/generator": {
-			"version": "7.0.0-beta.44",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.44.tgz",
-			"integrity": "sha512-5xVb7hlhjGcdkKpMXgicAVgx8syK5VJz193k0i/0sLP6DzE6lRrU1K3B/rFefgdo9LPGMAOOOAWW4jycj07ShQ==",
+		"node_modules/@babel/helper-validator-identifier": {
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+			"integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
 			"dev": true,
-			"dependencies": {
-				"@babel/types": "7.0.0-beta.44",
-				"jsesc": "^2.5.1",
-				"lodash": "^4.2.0",
-				"source-map": "^0.5.0",
-				"trim-right": "^1.0.1"
-			}
-		},
-		"node_modules/@babel/helper-function-name": {
-			"version": "7.0.0-beta.44",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
-			"integrity": "sha512-MHRG2qZMKMFaBavX0LWpfZ2e+hLloT++N7rfM3DYOMUOGCD8cVjqZpwiL8a0bOX3IYcQev1ruciT0gdFFRTxzg==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-get-function-arity": "7.0.0-beta.44",
-				"@babel/template": "7.0.0-beta.44",
-				"@babel/types": "7.0.0-beta.44"
-			}
-		},
-		"node_modules/@babel/helper-get-function-arity": {
-			"version": "7.0.0-beta.44",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
-			"integrity": "sha512-w0YjWVwrM2HwP6/H3sEgrSQdkCaxppqFeJtAnB23pRiJB5E/O9Yp7JAAeWBl+gGEgmBFinnTyOv2RN7rcSmMiw==",
-			"dev": true,
-			"dependencies": {
-				"@babel/types": "7.0.0-beta.44"
-			}
-		},
-		"node_modules/@babel/helper-split-export-declaration": {
-			"version": "7.0.0-beta.44",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
-			"integrity": "sha512-aQ7QowtkgKKzPGf0j6u77kBMdUFVBKNHw2p/3HX/POt5/oz8ec5cs0GwlgM8Hz7ui5EwJnzyfRmkNF1Nx1N7aA==",
-			"dev": true,
-			"dependencies": {
-				"@babel/types": "7.0.0-beta.44"
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/highlight": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
-			"integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+			"integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
 			"dev": true,
 			"dependencies": {
+				"@babel/helper-validator-identifier": "^7.18.6",
 				"chalk": "^2.0.0",
-				"esutils": "^2.0.2",
 				"js-tokens": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@babel/template": {
-			"version": "7.0.0-beta.44",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
-			"integrity": "sha512-w750Sloq0UNifLx1rUqwfbnC6uSUk0mfwwgGRfdLiaUzfAOiH0tHJE6ILQIUi3KYkjiCDTskoIsnfqZvWLBDng==",
-			"dev": true,
-			"dependencies": {
-				"@babel/code-frame": "7.0.0-beta.44",
-				"@babel/types": "7.0.0-beta.44",
-				"babylon": "7.0.0-beta.44",
-				"lodash": "^4.2.0"
-			}
-		},
-		"node_modules/@babel/template/node_modules/@babel/code-frame": {
-			"version": "7.0.0-beta.44",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
-			"integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
-			"dev": true,
-			"dependencies": {
-				"@babel/highlight": "7.0.0-beta.44"
-			}
-		},
-		"node_modules/@babel/template/node_modules/@babel/highlight": {
-			"version": "7.0.0-beta.44",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
-			"integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
-			"dev": true,
-			"dependencies": {
-				"chalk": "^2.0.0",
-				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.0"
-			}
-		},
-		"node_modules/@babel/template/node_modules/js-tokens": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-			"dev": true
-		},
-		"node_modules/@babel/traverse": {
-			"version": "7.0.0-beta.44",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.44.tgz",
-			"integrity": "sha512-UHuDz8ukQkJCDASKHf+oDt3FVUzFd+QYfuBIsiNu/4+/ix6pP/C+uQZJ6K1oEfbCMv/IKWbgDEh7fcsnIE5AtA==",
-			"dev": true,
-			"dependencies": {
-				"@babel/code-frame": "7.0.0-beta.44",
-				"@babel/generator": "7.0.0-beta.44",
-				"@babel/helper-function-name": "7.0.0-beta.44",
-				"@babel/helper-split-export-declaration": "7.0.0-beta.44",
-				"@babel/types": "7.0.0-beta.44",
-				"babylon": "7.0.0-beta.44",
-				"debug": "^3.1.0",
-				"globals": "^11.1.0",
-				"invariant": "^2.2.0",
-				"lodash": "^4.2.0"
-			}
-		},
-		"node_modules/@babel/traverse/node_modules/@babel/code-frame": {
-			"version": "7.0.0-beta.44",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
-			"integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
-			"dev": true,
-			"dependencies": {
-				"@babel/highlight": "7.0.0-beta.44"
-			}
-		},
-		"node_modules/@babel/traverse/node_modules/@babel/highlight": {
-			"version": "7.0.0-beta.44",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
-			"integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
-			"dev": true,
-			"dependencies": {
-				"chalk": "^2.0.0",
-				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.0"
-			}
-		},
-		"node_modules/@babel/traverse/node_modules/js-tokens": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-			"dev": true
-		},
-		"node_modules/@babel/types": {
-			"version": "7.0.0-beta.44",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
-			"integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
-			"dev": true,
-			"dependencies": {
-				"esutils": "^2.0.2",
-				"lodash": "^4.2.0",
-				"to-fast-properties": "^2.0.0"
-			}
+		"node_modules/@jridgewell/sourcemap-codec": {
+			"version": "1.4.14",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
 		},
 		"node_modules/@types/estree": {
 			"version": "0.0.50",
@@ -185,9 +69,9 @@
 			"integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
 		},
 		"node_modules/@types/node": {
-			"version": "12.12.7",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.7.tgz",
-			"integrity": "sha512-E6Zn0rffhgd130zbCbAr/JdXfXkoOUFAKNs/rF8qnafSJ8KYaA/j3oz7dcwal+lYjLA7xvdd5J4wdYpCTlP8+w==",
+			"version": "12.20.55",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+			"integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
 			"dev": true
 		},
 		"node_modules/acorn": {
@@ -211,62 +95,6 @@
 			},
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/babel-eslint": {
-			"version": "8.2.6",
-			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.6.tgz",
-			"integrity": "sha512-aCdHjhzcILdP8c9lej7hvXKvQieyRt20SF102SIGyY4cUIiw6UaAtK4j2o3dXX74jEmy0TJ0CEhv4fTIM3SzcA==",
-			"deprecated": "babel-eslint is now @babel/eslint-parser. This package will no longer receive updates.",
-			"dev": true,
-			"dependencies": {
-				"@babel/code-frame": "7.0.0-beta.44",
-				"@babel/traverse": "7.0.0-beta.44",
-				"@babel/types": "7.0.0-beta.44",
-				"babylon": "7.0.0-beta.44",
-				"eslint-scope": "3.7.1",
-				"eslint-visitor-keys": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/babel-eslint/node_modules/@babel/code-frame": {
-			"version": "7.0.0-beta.44",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
-			"integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
-			"dev": true,
-			"dependencies": {
-				"@babel/highlight": "7.0.0-beta.44"
-			}
-		},
-		"node_modules/babel-eslint/node_modules/@babel/highlight": {
-			"version": "7.0.0-beta.44",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
-			"integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
-			"dev": true,
-			"dependencies": {
-				"chalk": "^2.0.0",
-				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.0"
-			}
-		},
-		"node_modules/babel-eslint/node_modules/js-tokens": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-			"dev": true
-		},
-		"node_modules/babylon": {
-			"version": "7.0.0-beta.44",
-			"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
-			"integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
-			"dev": true,
-			"bin": {
-				"babylon": "bin/babylon.js"
-			},
-			"engines": {
-				"node": ">=4.2.0"
 			}
 		},
 		"node_modules/chalk": {
@@ -295,37 +123,37 @@
 		"node_modules/color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
 			"dev": true
 		},
-		"node_modules/debug": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-			"dev": true,
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
 		"node_modules/deep-is": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true
 		},
 		"node_modules/dequal": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
-			"integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
 			"dev": true,
 			"engines": {
 				"node": ">=6"
 			}
 		},
+		"node_modules/diff": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+			"integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+			"dev": true,
+			"engines": {
+				"node": ">=0.3.1"
+			}
+		},
 		"node_modules/esbuild": {
-			"version": "0.11.16",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.11.16.tgz",
-			"integrity": "sha512-34ZWjo4ouvM5cDe7uRoM9GFuMyEmpH9fnVYmomvS1cq9ED9d/0ZG1r+p4P2VbX7ihjv36zA2SWTmP8Zmt/EANA==",
+			"version": "0.11.23",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.11.23.tgz",
+			"integrity": "sha512-iaiZZ9vUF5wJV8ob1tl+5aJTrwDczlvGP0JoMmnpC2B0ppiMCu8n8gmy5ZTGl5bcG081XBVn+U+jP+mPFm5T5Q==",
 			"dev": true,
 			"hasInstallScript": true,
 			"bin": {
@@ -335,78 +163,44 @@
 		"node_modules/escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.8.0"
 			}
 		},
-		"node_modules/eslint-scope": {
-			"version": "3.7.1",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
-			"dev": true,
-			"dependencies": {
-				"esrecurse": "^4.1.0",
-				"estraverse": "^4.1.1"
-			},
-			"engines": {
-				"node": ">=4.0.0"
-			}
-		},
-		"node_modules/eslint-visitor-keys": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-			"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/eslump": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/eslump/-/eslump-2.0.0.tgz",
-			"integrity": "sha512-80p4ogK1rh8LWyTIRAeL4BEC1sSP0O/8JYNygSvLQXN0+zhKlTtRsESOsBUU+POHNISTifbefaEJNqpqZQxdKQ==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/eslump/-/eslump-3.0.0.tgz",
+			"integrity": "sha512-TAhAytVHCHMk0yDxCbS881uuAEPfoqdnmp2mkwDgBoM5lVBfoE9nYxq0LCdgJS8NASV8V8NIUF3N4YjhiuuTBg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/code-frame": "^7.0.0",
-				"mkdirp": "^0.5.1",
-				"optionator": "^0.8.2",
-				"random-int": "^1.0.0",
-				"random-item": "^1.0.0",
-				"shift-codegen": "5.1.0",
-				"shift-fuzzer": "^1.0.2",
-				"shift-reducer": "^5.0.0"
+				"@babel/code-frame": "^7.12.13",
+				"mkdirp": "^1.0.4",
+				"optionator": "^0.9.1",
+				"random-int": "^2.0.1",
+				"random-item": "^3.1.0",
+				"shift-codegen": "^7.0.3",
+				"shift-fuzzer": "^2.0.0",
+				"shift-parser": "^7.0.3",
+				"shift-reducer": "^6.0.0"
 			},
 			"bin": {
 				"eslump": "src/cli-runner.js"
 			}
 		},
-		"node_modules/esrecurse": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
-			"dev": true,
-			"dependencies": {
-				"estraverse": "^4.1.0"
-			},
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
-		"node_modules/estraverse": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-			"dev": true,
-			"engines": {
-				"node": ">=4.0"
-			}
-		},
 		"node_modules/estree-walker": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.0.tgz",
-			"integrity": "sha512-s6ceX0NFiU/vKPiKvFdR83U1Zffu7upwZsGwpoqfg5rbbq1l50WQ5hCeIvM6E6oD4shUHCYMsiFPns4Jk0YfMQ=="
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"dependencies": {
+				"@types/estree": "^1.0.0"
+			}
+		},
+		"node_modules/estree-walker/node_modules/@types/estree": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+			"integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ=="
 		},
 		"node_modules/esutils": {
 			"version": "2.0.3",
@@ -420,40 +214,22 @@
 		"node_modules/fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true
-		},
-		"node_modules/globals": {
-			"version": "11.12.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
 		},
 		"node_modules/has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
 			"dev": true,
 			"engines": {
 				"node": ">=4"
 			}
 		},
-		"node_modules/invariant": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-			"dev": true,
-			"dependencies": {
-				"loose-envify": "^1.0.0"
-			}
-		},
 		"node_modules/is-reference": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.0.tgz",
-			"integrity": "sha512-Eo1W3wUoHWoCoVM4GVl/a+K0IgiqE5aIo4kJABFyMum1ZORlPkC+UC357sSQUL5w5QCE5kCC9upl75b7+7CY/Q==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.1.tgz",
+			"integrity": "sha512-baJJdQLiYaJdvFbJqXrcGv3WU3QCzBlUcI5QhbesIm6/xPsvmO+2CDoi/GMOFBQEQm+PXkwOPrp9KK5ozZsp2w==",
 			"dependencies": {
 				"@types/estree": "*"
 			}
@@ -464,234 +240,212 @@
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
 			"dev": true
 		},
-		"node_modules/jsesc": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-			"dev": true,
-			"bin": {
-				"jsesc": "bin/jsesc"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/kleur": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
-			"integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+			"integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=6"
 			}
 		},
 		"node_modules/levn": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
 			"dev": true,
 			"dependencies": {
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2"
+				"prelude-ls": "^1.2.1",
+				"type-check": "~0.4.0"
 			},
 			"engines": {
 				"node": ">= 0.8.0"
 			}
 		},
-		"node_modules/lodash": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-			"dev": true
-		},
-		"node_modules/loose-envify": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-			"dev": true,
-			"dependencies": {
-				"js-tokens": "^3.0.0 || ^4.0.0"
-			},
-			"bin": {
-				"loose-envify": "cli.js"
-			}
-		},
-		"node_modules/minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-			"dev": true
-		},
 		"node_modules/mkdirp": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
 			"dev": true,
-			"dependencies": {
-				"minimist": "^1.2.5"
-			},
 			"bin": {
 				"mkdirp": "bin/cmd.js"
+			},
+			"engines": {
+				"node": ">=10"
 			}
 		},
 		"node_modules/mri": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/mri/-/mri-1.1.6.tgz",
-			"integrity": "sha512-oi1b3MfbyGa7FJMP9GmLTttni5JoICpYBRlq+x5V16fZbLsnL9N3wFqqIm/nIG43FjUFkFh9Epzp/kzUGUnJxQ==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+			"integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
 			"dev": true,
 			"engines": {
 				"node": ">=4"
 			}
 		},
-		"node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+		"node_modules/multimap": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/multimap/-/multimap-1.1.0.tgz",
+			"integrity": "sha512-0ZIR9PasPxGXmRsEF8jsDzndzHDj7tIav+JUmvIFB/WHswliFnquxECT/De7GR4yg99ky/NlRKJT82G1y271bw==",
 			"dev": true
 		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/optionator": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"version": "0.9.1",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+			"integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
 			"dev": true,
 			"dependencies": {
-				"deep-is": "~0.1.3",
-				"fast-levenshtein": "~2.0.4",
-				"levn": "~0.3.0",
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2",
-				"wordwrap": "~1.0.0"
+				"deep-is": "^0.1.3",
+				"fast-levenshtein": "^2.0.6",
+				"levn": "^0.4.1",
+				"prelude-ls": "^1.2.1",
+				"type-check": "^0.4.0",
+				"word-wrap": "^1.2.3"
 			},
 			"engines": {
 				"node": ">= 0.8.0"
 			}
 		},
 		"node_modules/periscopic": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.0.4.tgz",
-			"integrity": "sha512-SFx68DxCv0Iyo6APZuw/AKewkkThGwssmU0QWtTlvov3VAtPX+QJ4CadwSaz8nrT5jPIuxdvJWB4PnD2KNDxQg==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz",
+			"integrity": "sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==",
 			"dependencies": {
+				"@types/estree": "^1.0.0",
 				"estree-walker": "^3.0.0",
 				"is-reference": "^3.0.0"
 			}
 		},
+		"node_modules/periscopic/node_modules/@types/estree": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+			"integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ=="
+		},
 		"node_modules/prelude-ls": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
 			"dev": true,
 			"engines": {
 				"node": ">= 0.8.0"
 			}
 		},
 		"node_modules/random-int": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/random-int/-/random-int-1.0.0.tgz",
-			"integrity": "sha1-5qLtNEisnGZGoGV0Q7HBUhWS7Qg=",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/random-int/-/random-int-2.0.1.tgz",
+			"integrity": "sha512-YALjWK2Rt9EMIv9BF/3mvlzFWQathsvb5UZmN1QmhfIOfcQYXc/UcLzg0ablqesSBpBVLt2Tlwv/eTuBh4LXUQ==",
 			"dev": true,
 			"engines": {
-				"node": ">=0.10.0"
+				"node": ">=8"
 			}
 		},
 		"node_modules/random-item": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/random-item/-/random-item-1.0.0.tgz",
-			"integrity": "sha1-Fu4xYmywUMihaGpfD0KmuZoqrxE=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/random-item/-/random-item-3.1.0.tgz",
+			"integrity": "sha512-0DyAT8LYBNQKSkqcPjia/HNoWCZ5JWBdAQWjBQVh5DMVv3Fv7V90I8/AuUf8NW4zdFn27i9qj8Kp6wI5JsiiOA==",
 			"dev": true,
 			"engines": {
-				"node": ">=0.10.0"
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/sade": {
-			"version": "1.7.4",
-			"resolved": "https://registry.npmjs.org/sade/-/sade-1.7.4.tgz",
-			"integrity": "sha512-y5yauMD93rX840MwUJr7C1ysLFBgMspsdTo4UVrDg3fXDvtwOyIqykhVAAm6fk/3au77773itJStObgK+LKaiA==",
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+			"integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
 			"dev": true,
 			"dependencies": {
 				"mri": "^1.1.0"
 			},
 			"engines": {
-				"node": ">= 6"
+				"node": ">=6"
 			}
 		},
 		"node_modules/shift-ast": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/shift-ast/-/shift-ast-4.0.0.tgz",
-			"integrity": "sha1-HUFSoq3ShkSlKusuDIfYkl09l/8=",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/shift-ast/-/shift-ast-6.1.0.tgz",
+			"integrity": "sha512-Vj4XUIJIFPIh6VcBGJ1hjH/kM88XGer94Pr7Rvxa+idEylDsrwtLw268HoxGo5xReL6T3DdRl/9/Pr1XihZ/8Q==",
 			"dev": true
 		},
 		"node_modules/shift-codegen": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/shift-codegen/-/shift-codegen-5.1.0.tgz",
-			"integrity": "sha512-OpRpMYukx4uNyZl+4j192qlghA+orUuXQwCxGB4C7XWVCeFOoz9MVCAQ9XNMQqeZKHE9YNoMpBA/kzrVUFpqcQ==",
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/shift-codegen/-/shift-codegen-7.0.3.tgz",
+			"integrity": "sha512-dfCVVdBF0qZ6pkajQ3bjxRdNEltyxEITVe7tBJkQt2eCI3znUkSxq0VSe/tTWq1LKHeAS4HuOiqYEuHMFkSq9w==",
 			"dev": true,
 			"dependencies": {
-				"babel-eslint": "^8.2.2",
 				"esutils": "^2.0.2",
 				"object-assign": "^4.1.0",
-				"shift-reducer": "^4.3.0"
-			}
-		},
-		"node_modules/shift-codegen/node_modules/shift-reducer": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/shift-reducer/-/shift-reducer-4.4.1.tgz",
-			"integrity": "sha512-IJmk9grLnuO8vLSG5e52wFXaDLXJmVMGPXKQljhh/Pwb1mQL8OgCr6c4OYyIa3OInTH9rBtms3SwDFWsJzVEnA==",
-			"dev": true,
-			"dependencies": {
-				"shift-ast": "^4.0.0"
+				"shift-reducer": "6.0.0"
 			}
 		},
 		"node_modules/shift-fuzzer": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/shift-fuzzer/-/shift-fuzzer-1.0.2.tgz",
-			"integrity": "sha1-g7uuFHv2Aiqupyc+LiviJamZVys=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shift-fuzzer/-/shift-fuzzer-2.0.0.tgz",
+			"integrity": "sha512-hgV4jqXELYR0UpEDlTnYcv0GXvhXV/y3lyYNyGtTq1Q6EdFIC9LLHjlrfVFt7d1VyzJqPkl/fME31ta0KrHiTQ==",
 			"dev": true,
 			"dependencies": {
-				"shift-ast": "^4.0.0"
+				"shift-ast": "6.1.0"
 			}
 		},
-		"node_modules/shift-reducer": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/shift-reducer/-/shift-reducer-5.0.0.tgz",
-			"integrity": "sha512-Jgr6kPMZuzsQ63NdeLJT6BZvtJ6IDbYFBVqiid1bZlwxeJYq81Cj2Wc4UUERjO4Q9tz5U4KpWaZhitjcBvfiYA==",
+		"node_modules/shift-parser": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/shift-parser/-/shift-parser-7.0.3.tgz",
+			"integrity": "sha512-uYX2ORyZfKZrUc4iKKkO9KOhzUSxCrSBk7QK6ZmShId+BOo1gh1IwecVy97ynyOTpmhPWUttjC8BzsnQl65Zew==",
 			"dev": true,
 			"dependencies": {
-				"shift-ast": "5.0.0"
+				"multimap": "^1.0.2",
+				"shift-ast": "6.0.0",
+				"shift-reducer": "6.0.0",
+				"shift-regexp-acceptor": "2.0.3"
+			}
+		},
+		"node_modules/shift-parser/node_modules/shift-ast": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/shift-ast/-/shift-ast-6.0.0.tgz",
+			"integrity": "sha512-XXxDcEBWVBzqWXfNYJlLyJ1/9kMvOXVRXiqPjkOrTCC5qRsBvEMJMRLLFhU3tn8ue56Y7IZyBE6bexFum5QLUw==",
+			"dev": true
+		},
+		"node_modules/shift-reducer": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/shift-reducer/-/shift-reducer-6.0.0.tgz",
+			"integrity": "sha512-2rJraRP8drIOjvaE/sALa+0tGJmMVUzlmS3wIJerJbaYuCjpFAiF0WjkTOFVtz1144Nm/ECmqeG+7yRhuMVsMg==",
+			"dev": true,
+			"dependencies": {
+				"shift-ast": "6.0.0"
 			}
 		},
 		"node_modules/shift-reducer/node_modules/shift-ast": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/shift-ast/-/shift-ast-5.0.0.tgz",
-			"integrity": "sha512-kMhr/GwgrQ1U2kaa50sD5YxNDQEZHAZigVwrf/NNeezb6oiYnpPMV8v1WVRhCW8sjI7xUdzuPujSQ3gA2IuUAQ==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/shift-ast/-/shift-ast-6.0.0.tgz",
+			"integrity": "sha512-XXxDcEBWVBzqWXfNYJlLyJ1/9kMvOXVRXiqPjkOrTCC5qRsBvEMJMRLLFhU3tn8ue56Y7IZyBE6bexFum5QLUw==",
 			"dev": true
 		},
-		"node_modules/source-map": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+		"node_modules/shift-regexp-acceptor": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/shift-regexp-acceptor/-/shift-regexp-acceptor-2.0.3.tgz",
+			"integrity": "sha512-sxL7e5JNUFxm+gutFRXktX2D6KVgDAHNuDsk5XHB9Z+N5yXooZG6pdZ1GEbo3Jz6lF7ETYLBC4WAjIFm2RKTmA==",
 			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
+			"dependencies": {
+				"unicode-match-property-ecmascript": "1.0.4",
+				"unicode-match-property-value-ecmascript": "1.0.2",
+				"unicode-property-aliases-ecmascript": "1.0.4"
 			}
 		},
-		"node_modules/sourcemap-codec": {
-			"version": "1.4.8",
-			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
-		},
 		"node_modules/supports-color": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 			"dev": true,
 			"dependencies": {
 				"has-flag": "^3.0.0"
@@ -700,49 +454,22 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/to-fast-properties": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/totalist": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/totalist/-/totalist-2.0.0.tgz",
-			"integrity": "sha512-+Y17F0YzxfACxTyjfhnJQEe7afPA0GSpYlFkl2VFMxYP7jshQf9gXV7cH47EfToBumFThfKBvfAcoUn6fdNeRQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=6"
-			}
-		},
-		"node_modules/trim-right": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-			"dev": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/type-check": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
 			"dev": true,
 			"dependencies": {
-				"prelude-ls": "~1.1.2"
+				"prelude-ls": "^1.2.1"
 			},
 			"engines": {
 				"node": ">= 0.8.0"
 			}
 		},
 		"node_modules/typescript": {
-			"version": "3.7.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
-			"integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==",
+			"version": "3.9.10",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+			"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
 			"dev": true,
 			"bin": {
 				"tsc": "bin/tsc",
@@ -752,17 +479,56 @@
 				"node": ">=4.2.0"
 			}
 		},
+		"node_modules/unicode-canonical-property-names-ecmascript": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+			"integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/unicode-match-property-ecmascript": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+			"integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+			"dev": true,
+			"dependencies": {
+				"unicode-canonical-property-names-ecmascript": "^1.0.4",
+				"unicode-property-aliases-ecmascript": "^1.0.4"
+			},
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/unicode-match-property-value-ecmascript": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz",
+			"integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
+		"node_modules/unicode-property-aliases-ecmascript": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz",
+			"integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg==",
+			"dev": true,
+			"engines": {
+				"node": ">=4"
+			}
+		},
 		"node_modules/uvu": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.1.tgz",
-			"integrity": "sha512-JGxttnOGDFs77FaZ0yMUHIzczzQ5R1IlDeNW6Wymw6gAscwMdAffVOP6TlxLIfReZyK8tahoGwWZaTCJzNFDkg==",
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.6.tgz",
+			"integrity": "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==",
 			"dev": true,
 			"dependencies": {
 				"dequal": "^2.0.0",
 				"diff": "^5.0.0",
 				"kleur": "^4.0.3",
-				"sade": "^1.7.3",
-				"totalist": "^2.0.0"
+				"sade": "^1.7.3"
 			},
 			"bin": {
 				"uvu": "bin.js"
@@ -771,181 +537,47 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/uvu/node_modules/diff": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-			"integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+		"node_modules/word-wrap": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
 			"dev": true,
 			"engines": {
-				"node": ">=0.3.1"
+				"node": ">=0.10.0"
 			}
-		},
-		"node_modules/wordwrap": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
-			"dev": true
 		}
 	},
 	"dependencies": {
 		"@babel/code-frame": {
-			"version": "7.5.5",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-			"integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
+			"integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "^7.0.0"
+				"@babel/highlight": "^7.18.6"
 			}
 		},
-		"@babel/generator": {
-			"version": "7.0.0-beta.44",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.0.0-beta.44.tgz",
-			"integrity": "sha512-5xVb7hlhjGcdkKpMXgicAVgx8syK5VJz193k0i/0sLP6DzE6lRrU1K3B/rFefgdo9LPGMAOOOAWW4jycj07ShQ==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "7.0.0-beta.44",
-				"jsesc": "^2.5.1",
-				"lodash": "^4.2.0",
-				"source-map": "^0.5.0",
-				"trim-right": "^1.0.1"
-			}
-		},
-		"@babel/helper-function-name": {
-			"version": "7.0.0-beta.44",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz",
-			"integrity": "sha512-MHRG2qZMKMFaBavX0LWpfZ2e+hLloT++N7rfM3DYOMUOGCD8cVjqZpwiL8a0bOX3IYcQev1ruciT0gdFFRTxzg==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-get-function-arity": "7.0.0-beta.44",
-				"@babel/template": "7.0.0-beta.44",
-				"@babel/types": "7.0.0-beta.44"
-			}
-		},
-		"@babel/helper-get-function-arity": {
-			"version": "7.0.0-beta.44",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz",
-			"integrity": "sha512-w0YjWVwrM2HwP6/H3sEgrSQdkCaxppqFeJtAnB23pRiJB5E/O9Yp7JAAeWBl+gGEgmBFinnTyOv2RN7rcSmMiw==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "7.0.0-beta.44"
-			}
-		},
-		"@babel/helper-split-export-declaration": {
-			"version": "7.0.0-beta.44",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz",
-			"integrity": "sha512-aQ7QowtkgKKzPGf0j6u77kBMdUFVBKNHw2p/3HX/POt5/oz8ec5cs0GwlgM8Hz7ui5EwJnzyfRmkNF1Nx1N7aA==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "7.0.0-beta.44"
-			}
+		"@babel/helper-validator-identifier": {
+			"version": "7.19.1",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+			"integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
+			"dev": true
 		},
 		"@babel/highlight": {
-			"version": "7.5.0",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
-			"integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
+			"version": "7.18.6",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+			"integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
 			"dev": true,
 			"requires": {
+				"@babel/helper-validator-identifier": "^7.18.6",
 				"chalk": "^2.0.0",
-				"esutils": "^2.0.2",
 				"js-tokens": "^4.0.0"
 			}
 		},
-		"@babel/template": {
-			"version": "7.0.0-beta.44",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.44.tgz",
-			"integrity": "sha512-w750Sloq0UNifLx1rUqwfbnC6uSUk0mfwwgGRfdLiaUzfAOiH0tHJE6ILQIUi3KYkjiCDTskoIsnfqZvWLBDng==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "7.0.0-beta.44",
-				"@babel/types": "7.0.0-beta.44",
-				"babylon": "7.0.0-beta.44",
-				"lodash": "^4.2.0"
-			},
-			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.0.0-beta.44",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
-					"integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
-					"dev": true,
-					"requires": {
-						"@babel/highlight": "7.0.0-beta.44"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.0.0-beta.44",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
-					"integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^3.0.0"
-					}
-				},
-				"js-tokens": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-					"dev": true
-				}
-			}
-		},
-		"@babel/traverse": {
-			"version": "7.0.0-beta.44",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.44.tgz",
-			"integrity": "sha512-UHuDz8ukQkJCDASKHf+oDt3FVUzFd+QYfuBIsiNu/4+/ix6pP/C+uQZJ6K1oEfbCMv/IKWbgDEh7fcsnIE5AtA==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "7.0.0-beta.44",
-				"@babel/generator": "7.0.0-beta.44",
-				"@babel/helper-function-name": "7.0.0-beta.44",
-				"@babel/helper-split-export-declaration": "7.0.0-beta.44",
-				"@babel/types": "7.0.0-beta.44",
-				"babylon": "7.0.0-beta.44",
-				"debug": "^3.1.0",
-				"globals": "^11.1.0",
-				"invariant": "^2.2.0",
-				"lodash": "^4.2.0"
-			},
-			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.0.0-beta.44",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
-					"integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
-					"dev": true,
-					"requires": {
-						"@babel/highlight": "7.0.0-beta.44"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.0.0-beta.44",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
-					"integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^3.0.0"
-					}
-				},
-				"js-tokens": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-					"dev": true
-				}
-			}
-		},
-		"@babel/types": {
-			"version": "7.0.0-beta.44",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.44.tgz",
-			"integrity": "sha512-5eTV4WRmqbaFM3v9gHAIljEQJU4Ssc6fxL61JN+Oe2ga/BwyjzjamwkCVVAQjHGuAX8i0BWo42dshL8eO5KfLQ==",
-			"dev": true,
-			"requires": {
-				"esutils": "^2.0.2",
-				"lodash": "^4.2.0",
-				"to-fast-properties": "^2.0.0"
-			}
+		"@jridgewell/sourcemap-codec": {
+			"version": "1.4.14",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
+			"integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
 		},
 		"@types/estree": {
 			"version": "0.0.50",
@@ -953,9 +585,9 @@
 			"integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw=="
 		},
 		"@types/node": {
-			"version": "12.12.7",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.7.tgz",
-			"integrity": "sha512-E6Zn0rffhgd130zbCbAr/JdXfXkoOUFAKNs/rF8qnafSJ8KYaA/j3oz7dcwal+lYjLA7xvdd5J4wdYpCTlP8+w==",
+			"version": "12.20.55",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.55.tgz",
+			"integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
 			"dev": true
 		},
 		"acorn": {
@@ -971,54 +603,6 @@
 			"requires": {
 				"color-convert": "^1.9.0"
 			}
-		},
-		"babel-eslint": {
-			"version": "8.2.6",
-			"resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.2.6.tgz",
-			"integrity": "sha512-aCdHjhzcILdP8c9lej7hvXKvQieyRt20SF102SIGyY4cUIiw6UaAtK4j2o3dXX74jEmy0TJ0CEhv4fTIM3SzcA==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "7.0.0-beta.44",
-				"@babel/traverse": "7.0.0-beta.44",
-				"@babel/types": "7.0.0-beta.44",
-				"babylon": "7.0.0-beta.44",
-				"eslint-scope": "3.7.1",
-				"eslint-visitor-keys": "^1.0.0"
-			},
-			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.0.0-beta.44",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz",
-					"integrity": "sha512-cuAuTTIQ9RqcFRJ/Y8PvTh+paepNcaGxwQwjIDRWPXmzzyAeCO4KqS9ikMvq0MCbRk6GlYKwfzStrcP3/jSL8g==",
-					"dev": true,
-					"requires": {
-						"@babel/highlight": "7.0.0-beta.44"
-					}
-				},
-				"@babel/highlight": {
-					"version": "7.0.0-beta.44",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0-beta.44.tgz",
-					"integrity": "sha512-Il19yJvy7vMFm8AVAh6OZzaFoAd0hbkeMZiX3P5HGD+z7dyI7RzndHB0dg6Urh/VAFfHtpOIzDUSxmY6coyZWQ==",
-					"dev": true,
-					"requires": {
-						"chalk": "^2.0.0",
-						"esutils": "^2.0.2",
-						"js-tokens": "^3.0.0"
-					}
-				},
-				"js-tokens": {
-					"version": "3.0.2",
-					"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-					"integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-					"dev": true
-				}
-			}
-		},
-		"babylon": {
-			"version": "7.0.0-beta.44",
-			"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.44.tgz",
-			"integrity": "sha512-5Hlm13BJVAioCHpImtFqNOF2H3ieTOHd0fmFGMxOJ9jgeFqeAwsv3u5P5cR7CSeFrkgHsT19DgFJkHV0/Mcd8g==",
-			"dev": true
 		},
 		"chalk": {
 			"version": "2.4.2",
@@ -1043,93 +627,70 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
 			"dev": true
 		},
-		"debug": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-			"dev": true,
-			"requires": {
-				"ms": "2.0.0"
-			}
-		},
 		"deep-is": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true
 		},
 		"dequal": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.2.tgz",
-			"integrity": "sha512-q9K8BlJVxK7hQYqa6XISGmBZbtQQWVXSrRrWreHC94rMt1QL/Impruc+7p2CYSYuVIUr+YCt6hjrs1kkdJRTug==",
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+			"dev": true
+		},
+		"diff": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
+			"integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
 			"dev": true
 		},
 		"esbuild": {
-			"version": "0.11.16",
-			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.11.16.tgz",
-			"integrity": "sha512-34ZWjo4ouvM5cDe7uRoM9GFuMyEmpH9fnVYmomvS1cq9ED9d/0ZG1r+p4P2VbX7ihjv36zA2SWTmP8Zmt/EANA==",
+			"version": "0.11.23",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.11.23.tgz",
+			"integrity": "sha512-iaiZZ9vUF5wJV8ob1tl+5aJTrwDczlvGP0JoMmnpC2B0ppiMCu8n8gmy5ZTGl5bcG081XBVn+U+jP+mPFm5T5Q==",
 			"dev": true
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
-		},
-		"eslint-scope": {
-			"version": "3.7.1",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
-			"integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
-			"dev": true,
-			"requires": {
-				"esrecurse": "^4.1.0",
-				"estraverse": "^4.1.1"
-			}
-		},
-		"eslint-visitor-keys": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-			"integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
 			"dev": true
 		},
 		"eslump": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/eslump/-/eslump-2.0.0.tgz",
-			"integrity": "sha512-80p4ogK1rh8LWyTIRAeL4BEC1sSP0O/8JYNygSvLQXN0+zhKlTtRsESOsBUU+POHNISTifbefaEJNqpqZQxdKQ==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/eslump/-/eslump-3.0.0.tgz",
+			"integrity": "sha512-TAhAytVHCHMk0yDxCbS881uuAEPfoqdnmp2mkwDgBoM5lVBfoE9nYxq0LCdgJS8NASV8V8NIUF3N4YjhiuuTBg==",
 			"dev": true,
 			"requires": {
-				"@babel/code-frame": "^7.0.0",
-				"mkdirp": "^0.5.1",
-				"optionator": "^0.8.2",
-				"random-int": "^1.0.0",
-				"random-item": "^1.0.0",
-				"shift-codegen": "5.1.0",
-				"shift-fuzzer": "^1.0.2",
-				"shift-reducer": "^5.0.0"
+				"@babel/code-frame": "^7.12.13",
+				"mkdirp": "^1.0.4",
+				"optionator": "^0.9.1",
+				"random-int": "^2.0.1",
+				"random-item": "^3.1.0",
+				"shift-codegen": "^7.0.3",
+				"shift-fuzzer": "^2.0.0",
+				"shift-parser": "^7.0.3",
+				"shift-reducer": "^6.0.0"
 			}
-		},
-		"esrecurse": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-			"integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
-			"dev": true,
-			"requires": {
-				"estraverse": "^4.1.0"
-			}
-		},
-		"estraverse": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-			"dev": true
 		},
 		"estree-walker": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.0.tgz",
-			"integrity": "sha512-s6ceX0NFiU/vKPiKvFdR83U1Zffu7upwZsGwpoqfg5rbbq1l50WQ5hCeIvM6E6oD4shUHCYMsiFPns4Jk0YfMQ=="
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+			"integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+			"requires": {
+				"@types/estree": "^1.0.0"
+			},
+			"dependencies": {
+				"@types/estree": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+					"integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ=="
+				}
+			}
 		},
 		"esutils": {
 			"version": "2.0.3",
@@ -1140,34 +701,19 @@
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-			"dev": true
-		},
-		"globals": {
-			"version": "11.12.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true
 		},
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
 			"dev": true
 		},
-		"invariant": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-			"dev": true,
-			"requires": {
-				"loose-envify": "^1.0.0"
-			}
-		},
 		"is-reference": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.0.tgz",
-			"integrity": "sha512-Eo1W3wUoHWoCoVM4GVl/a+K0IgiqE5aIo4kJABFyMum1ZORlPkC+UC357sSQUL5w5QCE5kCC9upl75b7+7CY/Q==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.1.tgz",
+			"integrity": "sha512-baJJdQLiYaJdvFbJqXrcGv3WU3QCzBlUcI5QhbesIm6/xPsvmO+2CDoi/GMOFBQEQm+PXkwOPrp9KK5ozZsp2w==",
 			"requires": {
 				"@types/estree": "*"
 			}
@@ -1178,259 +724,246 @@
 			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
 			"dev": true
 		},
-		"jsesc": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-			"dev": true
-		},
 		"kleur": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.4.tgz",
-			"integrity": "sha512-8QADVssbrFjivHWQU7KkMgptGTl6WAcSdlbBPY4uNF+mWr6DGcKrvY2w4FQJoXch7+fKMjj0dRrL75vk3k23OA==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+			"integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
 			"dev": true
 		},
 		"levn": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
-			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"version": "0.4.1",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2"
+				"prelude-ls": "^1.2.1",
+				"type-check": "~0.4.0"
 			}
-		},
-		"lodash": {
-			"version": "4.17.21",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-			"dev": true
-		},
-		"loose-envify": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-			"dev": true,
-			"requires": {
-				"js-tokens": "^3.0.0 || ^4.0.0"
-			}
-		},
-		"minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-			"dev": true
 		},
 		"mkdirp": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-			"dev": true,
-			"requires": {
-				"minimist": "^1.2.5"
-			}
-		},
-		"mri": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/mri/-/mri-1.1.6.tgz",
-			"integrity": "sha512-oi1b3MfbyGa7FJMP9GmLTttni5JoICpYBRlq+x5V16fZbLsnL9N3wFqqIm/nIG43FjUFkFh9Epzp/kzUGUnJxQ==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
 			"dev": true
 		},
-		"ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+		"mri": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/mri/-/mri-1.2.0.tgz",
+			"integrity": "sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==",
+			"dev": true
+		},
+		"multimap": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/multimap/-/multimap-1.1.0.tgz",
+			"integrity": "sha512-0ZIR9PasPxGXmRsEF8jsDzndzHDj7tIav+JUmvIFB/WHswliFnquxECT/De7GR4yg99ky/NlRKJT82G1y271bw==",
 			"dev": true
 		},
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
 			"dev": true
 		},
 		"optionator": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
-			"integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+			"version": "0.9.1",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.1.tgz",
+			"integrity": "sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==",
 			"dev": true,
 			"requires": {
-				"deep-is": "~0.1.3",
-				"fast-levenshtein": "~2.0.4",
-				"levn": "~0.3.0",
-				"prelude-ls": "~1.1.2",
-				"type-check": "~0.3.2",
-				"wordwrap": "~1.0.0"
+				"deep-is": "^0.1.3",
+				"fast-levenshtein": "^2.0.6",
+				"levn": "^0.4.1",
+				"prelude-ls": "^1.2.1",
+				"type-check": "^0.4.0",
+				"word-wrap": "^1.2.3"
 			}
 		},
 		"periscopic": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.0.4.tgz",
-			"integrity": "sha512-SFx68DxCv0Iyo6APZuw/AKewkkThGwssmU0QWtTlvov3VAtPX+QJ4CadwSaz8nrT5jPIuxdvJWB4PnD2KNDxQg==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/periscopic/-/periscopic-3.1.0.tgz",
+			"integrity": "sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==",
 			"requires": {
+				"@types/estree": "^1.0.0",
 				"estree-walker": "^3.0.0",
 				"is-reference": "^3.0.0"
+			},
+			"dependencies": {
+				"@types/estree": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.0.tgz",
+					"integrity": "sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ=="
+				}
 			}
 		},
 		"prelude-ls": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
 			"dev": true
 		},
 		"random-int": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/random-int/-/random-int-1.0.0.tgz",
-			"integrity": "sha1-5qLtNEisnGZGoGV0Q7HBUhWS7Qg=",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/random-int/-/random-int-2.0.1.tgz",
+			"integrity": "sha512-YALjWK2Rt9EMIv9BF/3mvlzFWQathsvb5UZmN1QmhfIOfcQYXc/UcLzg0ablqesSBpBVLt2Tlwv/eTuBh4LXUQ==",
 			"dev": true
 		},
 		"random-item": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/random-item/-/random-item-1.0.0.tgz",
-			"integrity": "sha1-Fu4xYmywUMihaGpfD0KmuZoqrxE=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/random-item/-/random-item-3.1.0.tgz",
+			"integrity": "sha512-0DyAT8LYBNQKSkqcPjia/HNoWCZ5JWBdAQWjBQVh5DMVv3Fv7V90I8/AuUf8NW4zdFn27i9qj8Kp6wI5JsiiOA==",
 			"dev": true
 		},
 		"sade": {
-			"version": "1.7.4",
-			"resolved": "https://registry.npmjs.org/sade/-/sade-1.7.4.tgz",
-			"integrity": "sha512-y5yauMD93rX840MwUJr7C1ysLFBgMspsdTo4UVrDg3fXDvtwOyIqykhVAAm6fk/3au77773itJStObgK+LKaiA==",
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/sade/-/sade-1.8.1.tgz",
+			"integrity": "sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==",
 			"dev": true,
 			"requires": {
 				"mri": "^1.1.0"
 			}
 		},
 		"shift-ast": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/shift-ast/-/shift-ast-4.0.0.tgz",
-			"integrity": "sha1-HUFSoq3ShkSlKusuDIfYkl09l/8=",
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/shift-ast/-/shift-ast-6.1.0.tgz",
+			"integrity": "sha512-Vj4XUIJIFPIh6VcBGJ1hjH/kM88XGer94Pr7Rvxa+idEylDsrwtLw268HoxGo5xReL6T3DdRl/9/Pr1XihZ/8Q==",
 			"dev": true
 		},
 		"shift-codegen": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/shift-codegen/-/shift-codegen-5.1.0.tgz",
-			"integrity": "sha512-OpRpMYukx4uNyZl+4j192qlghA+orUuXQwCxGB4C7XWVCeFOoz9MVCAQ9XNMQqeZKHE9YNoMpBA/kzrVUFpqcQ==",
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/shift-codegen/-/shift-codegen-7.0.3.tgz",
+			"integrity": "sha512-dfCVVdBF0qZ6pkajQ3bjxRdNEltyxEITVe7tBJkQt2eCI3znUkSxq0VSe/tTWq1LKHeAS4HuOiqYEuHMFkSq9w==",
 			"dev": true,
 			"requires": {
-				"babel-eslint": "^8.2.2",
 				"esutils": "^2.0.2",
 				"object-assign": "^4.1.0",
-				"shift-reducer": "^4.3.0"
-			},
-			"dependencies": {
-				"shift-reducer": {
-					"version": "4.4.1",
-					"resolved": "https://registry.npmjs.org/shift-reducer/-/shift-reducer-4.4.1.tgz",
-					"integrity": "sha512-IJmk9grLnuO8vLSG5e52wFXaDLXJmVMGPXKQljhh/Pwb1mQL8OgCr6c4OYyIa3OInTH9rBtms3SwDFWsJzVEnA==",
-					"dev": true,
-					"requires": {
-						"shift-ast": "^4.0.0"
-					}
-				}
+				"shift-reducer": "6.0.0"
 			}
 		},
 		"shift-fuzzer": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/shift-fuzzer/-/shift-fuzzer-1.0.2.tgz",
-			"integrity": "sha1-g7uuFHv2Aiqupyc+LiviJamZVys=",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/shift-fuzzer/-/shift-fuzzer-2.0.0.tgz",
+			"integrity": "sha512-hgV4jqXELYR0UpEDlTnYcv0GXvhXV/y3lyYNyGtTq1Q6EdFIC9LLHjlrfVFt7d1VyzJqPkl/fME31ta0KrHiTQ==",
 			"dev": true,
 			"requires": {
-				"shift-ast": "^4.0.0"
+				"shift-ast": "6.1.0"
 			}
 		},
-		"shift-reducer": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/shift-reducer/-/shift-reducer-5.0.0.tgz",
-			"integrity": "sha512-Jgr6kPMZuzsQ63NdeLJT6BZvtJ6IDbYFBVqiid1bZlwxeJYq81Cj2Wc4UUERjO4Q9tz5U4KpWaZhitjcBvfiYA==",
+		"shift-parser": {
+			"version": "7.0.3",
+			"resolved": "https://registry.npmjs.org/shift-parser/-/shift-parser-7.0.3.tgz",
+			"integrity": "sha512-uYX2ORyZfKZrUc4iKKkO9KOhzUSxCrSBk7QK6ZmShId+BOo1gh1IwecVy97ynyOTpmhPWUttjC8BzsnQl65Zew==",
 			"dev": true,
 			"requires": {
-				"shift-ast": "5.0.0"
+				"multimap": "^1.0.2",
+				"shift-ast": "6.0.0",
+				"shift-reducer": "6.0.0",
+				"shift-regexp-acceptor": "2.0.3"
 			},
 			"dependencies": {
 				"shift-ast": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/shift-ast/-/shift-ast-5.0.0.tgz",
-					"integrity": "sha512-kMhr/GwgrQ1U2kaa50sD5YxNDQEZHAZigVwrf/NNeezb6oiYnpPMV8v1WVRhCW8sjI7xUdzuPujSQ3gA2IuUAQ==",
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/shift-ast/-/shift-ast-6.0.0.tgz",
+					"integrity": "sha512-XXxDcEBWVBzqWXfNYJlLyJ1/9kMvOXVRXiqPjkOrTCC5qRsBvEMJMRLLFhU3tn8ue56Y7IZyBE6bexFum5QLUw==",
 					"dev": true
 				}
 			}
 		},
-		"source-map": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-			"dev": true
+		"shift-reducer": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/shift-reducer/-/shift-reducer-6.0.0.tgz",
+			"integrity": "sha512-2rJraRP8drIOjvaE/sALa+0tGJmMVUzlmS3wIJerJbaYuCjpFAiF0WjkTOFVtz1144Nm/ECmqeG+7yRhuMVsMg==",
+			"dev": true,
+			"requires": {
+				"shift-ast": "6.0.0"
+			},
+			"dependencies": {
+				"shift-ast": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/shift-ast/-/shift-ast-6.0.0.tgz",
+					"integrity": "sha512-XXxDcEBWVBzqWXfNYJlLyJ1/9kMvOXVRXiqPjkOrTCC5qRsBvEMJMRLLFhU3tn8ue56Y7IZyBE6bexFum5QLUw==",
+					"dev": true
+				}
+			}
 		},
-		"sourcemap-codec": {
-			"version": "1.4.8",
-			"resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-			"integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+		"shift-regexp-acceptor": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/shift-regexp-acceptor/-/shift-regexp-acceptor-2.0.3.tgz",
+			"integrity": "sha512-sxL7e5JNUFxm+gutFRXktX2D6KVgDAHNuDsk5XHB9Z+N5yXooZG6pdZ1GEbo3Jz6lF7ETYLBC4WAjIFm2RKTmA==",
+			"dev": true,
+			"requires": {
+				"unicode-match-property-ecmascript": "1.0.4",
+				"unicode-match-property-value-ecmascript": "1.0.2",
+				"unicode-property-aliases-ecmascript": "1.0.4"
+			}
 		},
 		"supports-color": {
-			"version": "5.4.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
-			"integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
 			"dev": true,
 			"requires": {
 				"has-flag": "^3.0.0"
 			}
 		},
-		"to-fast-properties": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-			"dev": true
-		},
-		"totalist": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/totalist/-/totalist-2.0.0.tgz",
-			"integrity": "sha512-+Y17F0YzxfACxTyjfhnJQEe7afPA0GSpYlFkl2VFMxYP7jshQf9gXV7cH47EfToBumFThfKBvfAcoUn6fdNeRQ==",
-			"dev": true
-		},
-		"trim-right": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-			"integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
-			"dev": true
-		},
 		"type-check": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
-			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
 			"dev": true,
 			"requires": {
-				"prelude-ls": "~1.1.2"
+				"prelude-ls": "^1.2.1"
 			}
 		},
 		"typescript": {
-			"version": "3.7.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.7.2.tgz",
-			"integrity": "sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==",
+			"version": "3.9.10",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.10.tgz",
+			"integrity": "sha512-w6fIxVE/H1PkLKcCPsFqKE7Kv7QUwhU8qQY2MueZXWx5cPZdwFupLgKK3vntcK98BtNHZtAF4LA/yl2a7k8R6Q==",
+			"dev": true
+		},
+		"unicode-canonical-property-names-ecmascript": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
+			"integrity": "sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==",
+			"dev": true
+		},
+		"unicode-match-property-ecmascript": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/unicode-match-property-ecmascript/-/unicode-match-property-ecmascript-1.0.4.tgz",
+			"integrity": "sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==",
+			"dev": true,
+			"requires": {
+				"unicode-canonical-property-names-ecmascript": "^1.0.4",
+				"unicode-property-aliases-ecmascript": "^1.0.4"
+			}
+		},
+		"unicode-match-property-value-ecmascript": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz",
+			"integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ==",
+			"dev": true
+		},
+		"unicode-property-aliases-ecmascript": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz",
+			"integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg==",
 			"dev": true
 		},
 		"uvu": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.1.tgz",
-			"integrity": "sha512-JGxttnOGDFs77FaZ0yMUHIzczzQ5R1IlDeNW6Wymw6gAscwMdAffVOP6TlxLIfReZyK8tahoGwWZaTCJzNFDkg==",
+			"version": "0.5.6",
+			"resolved": "https://registry.npmjs.org/uvu/-/uvu-0.5.6.tgz",
+			"integrity": "sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==",
 			"dev": true,
 			"requires": {
 				"dequal": "^2.0.0",
 				"diff": "^5.0.0",
 				"kleur": "^4.0.3",
-				"sade": "^1.7.3",
-				"totalist": "^2.0.0"
-			},
-			"dependencies": {
-				"diff": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
-					"integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
-					"dev": true
-				}
+				"sade": "^1.7.3"
 			}
 		},
-		"wordwrap": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-			"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+		"word-wrap": {
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
+			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
 			"dev": true
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -25,12 +25,12 @@
 	"license": "MIT",
 	"dependencies": {
 		"@jridgewell/sourcemap-codec": "^1.4.14",
+		"@types/estree": "^0.0.50",
 		"acorn": "^8.0.5",
 		"estree-walker": "^3.0.0",
 		"periscopic": "^3.0.4"
 	},
 	"devDependencies": {
-		"@types/estree": "^0.0.50",
 		"@types/node": "^12.12.7",
 		"esbuild": "^0.11.16",
 		"eslump": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -16,26 +16,25 @@
 		"dist",
 		"types"
 	],
-	"devDependencies": {
-		"@types/node": "^12.12.7",
-		"esbuild": "^0.11.16",
-		"eslump": "^2.0.0",
-		"typescript": "^3.7.2",
-		"uvu": "^0.5.1"
-	},
 	"scripts": {
-		"build": "tsc && esbuild --bundle --external:acorn --external:estree-walker --external:is-reference --external:periscopic --external:sourcemap-codec --format=cjs --outfile=dist/code-red.cjs src/index.js",
+		"build": "tsc && esbuild --bundle --external:acorn --external:estree-walker --external:is-reference --external:periscopic --external:@jridgewell/sourcemap-codec --format=cjs --outfile=dist/code-red.cjs src/index.js",
 		"test": "uvu test test.js",
 		"prepublishOnly": "npm test && npm run build",
 		"repl": "node -e \"const { x, b, print } = require('./dist/code-red.cjs')\" -i"
 	},
 	"license": "MIT",
 	"dependencies": {
-		"@types/estree": "^0.0.50",
+		"@jridgewell/sourcemap-codec": "^1.4.14",
 		"acorn": "^8.0.5",
 		"estree-walker": "^3.0.0",
-		"is-reference": "^3.0.0",
-		"periscopic": "^3.0.4",
-		"sourcemap-codec": "^1.4.8"
+		"periscopic": "^3.0.4"
+	},
+	"devDependencies": {
+		"@types/estree": "^0.0.50",
+		"@types/node": "^12.12.7",
+		"esbuild": "^0.11.16",
+		"eslump": "^3.0.0",
+		"typescript": "^3.7.2",
+		"uvu": "^0.5.6"
 	}
 }

--- a/src/print/index.js
+++ b/src/print/index.js
@@ -1,6 +1,6 @@
 import * as perisopic from 'periscopic';
 import { handle } from './handlers.js';
-import { encode } from 'sourcemap-codec';
+import { encode } from '@jridgewell/sourcemap-codec';
 
 /** @type {(str?: string) => string} str */
 let btoa = () => {

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,5 @@
 // @ts-check
+import { decode } from '@jridgewell/sourcemap-codec';
 import * as fs from 'fs';
 import * as acorn from 'acorn';
 import * as uvu from 'uvu';
@@ -6,7 +7,6 @@ import * as assert from 'assert';
 import { generateRandomJS } from 'eslump';
 import * as codered from '../src/index.js';
 import { walk } from 'estree-walker';
-import { decode } from 'sourcemap-codec';
 import { fileURLToPath } from 'url';
 
 /** @typedef {import('estree').Identifier} Identifier */


### PR DESCRIPTION
Also removed `is-reference` as unused and moved `@types/estree` to `devDependencies`

`npm run repl` was broken before this PR because `estree-walker` no longer has a CJS distributable. Should we drop CJS from this package as well since it's broken and not working?